### PR TITLE
Add support for disabling API version checks via a config property

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
 import org.springframework.cloud.servicebroker.model.BrokerApiVersion;
@@ -37,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @ConditionalOnBean(ServiceInstanceService.class)
+@ConditionalOnProperty(prefix = "spring.cloud.openservicebroker", name = "apiVersionCheckEnabled", havingValue = "true", matchIfMissing = true)
 @AutoConfigureAfter(WebFluxAutoConfiguration.class)
 public class ApiVersionWebFluxAutoConfiguration {
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.cloud.servicebroker.model.BrokerApiVersion;
@@ -38,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnBean({ServiceInstanceService.class})
+@ConditionalOnProperty(prefix = "spring.cloud.openservicebroker", name = "apiVersionCheckEnabled", havingValue = "true", matchIfMissing = true)
 @AutoConfigureAfter(WebMvcAutoConfiguration.class)
 public class ApiVersionWebMvcAutoConfiguration {
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfigurationTest.java
@@ -74,6 +74,17 @@ public class ApiVersionWebFluxAutoConfigurationTest {
 				});
 	}
 
+	@Test
+	public void apiVersionCheckIsDisabled() {
+		webApplicationContextRunner()
+				.withUserConfiguration(ServicesConfiguration.class)
+				.withPropertyValues("spring.cloud.openservicebroker.apiVersionCheckEnabled=false")
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean(BrokerApiVersion.class);
+					assertThat(context).doesNotHaveBean(ApiVersionWebFilter.class);
+				});
+	}
+
 	private ReactiveWebApplicationContextRunner webApplicationContextRunner() {
 		return new ReactiveWebApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(ApiVersionWebFluxAutoConfiguration.class));

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfigurationTest.java
@@ -17,10 +17,12 @@
 package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
 
 import org.junit.Test;
+
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.cloud.servicebroker.autoconfigure.web.TestServiceInstanceService;
+import org.springframework.cloud.servicebroker.autoconfigure.web.reactive.ApiVersionWebFilter;
 import org.springframework.cloud.servicebroker.model.BrokerApiVersion;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
 import org.springframework.context.annotation.Bean;
@@ -73,6 +75,17 @@ public class ApiVersionWebMvcAutoConfigurationTest {
 							.hasFieldOrPropertyWithValue("apiVersion", API_VERSION_CURRENT);
 					assertThat(context).hasSingleBean(ApiVersionInterceptor.class);
 					assertThat(context).hasSingleBean(ApiVersionWebMvcConfigurerAdapter.class);
+				});
+	}
+
+	@Test
+	public void apiVersionCheckIsDisabled() {
+		webApplicationContextRunner()
+				.withUserConfiguration(ServicesConfiguration.class)
+				.withPropertyValues("spring.cloud.openservicebroker.apiVersionCheckEnabled=false")
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean(BrokerApiVersion.class);
+					assertThat(context).doesNotHaveBean(ApiVersionWebFilter.class);
 				});
 	}
 


### PR DESCRIPTION
The following property will disable the API version check
auto-configuration for WebFlux or MVC based applications

spring.cloud.openservicebroker.apiVersionCheckEnabled=false

Resolves #68