### PR TITLE
Remove generic exception handler to allow service specific handling.

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
@@ -214,12 +214,6 @@ public class BaseController {
 		return getErrorResponse(message.toString(), HttpStatus.UNPROCESSABLE_ENTITY);
 	}
 
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorMessage> handleException(Exception ex) {
-		logger.error("Unknown exception handled: ", ex);
-		return getErrorResponse(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-	}
-
 	protected ResponseEntity<ErrorMessage> getErrorResponse(String message, HttpStatus status) {
 		return new ResponseEntity<>(new ErrorMessage(message), status);
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -167,6 +167,12 @@ public class ServiceInstanceBindingController extends BaseController {
 		return new ResponseEntity<>("{}", HttpStatus.OK);
 	}
 
+	@ExceptionHandler(UnsupportedOperationException.class)
+	public ResponseEntity<ErrorMessage> handleException(UnsupportedOperationException ex) {
+		logger.debug(ex.getMessage(), ex);
+		return getErrorResponse(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
 	@ExceptionHandler(ServiceInstanceBindingExistsException.class)
 	public ResponseEntity<ErrorMessage> handleException(ServiceInstanceBindingExistsException ex) {
 		logger.debug(ex.getMessage(), ex);

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
@@ -209,17 +209,6 @@ public class BaseControllerTest {
 	}
 
 	@Test
-	public void unknownExceptionGivesExpectedStatus() {
-		Exception exception = new Exception("test message");
-
-		ResponseEntity<ErrorMessage> responseEntity = controller.handleException(exception);
-
-		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-		assertThat(responseEntity.getBody().getError()).isNull();
-		assertThat(responseEntity.getBody().getMessage()).contains("test message");
-	}
-
-	@Test
 	public void methodArgumentNotValidExceptionGivesExpectedStatus() throws NoSuchMethodException {
 		BindingResult bindingResult = new MapBindingResult(new HashMap<>(), "objectName");
 		bindingResult.addError(new FieldError("objectName", "field1", "message"));


### PR DESCRIPTION
To make sure, that non-bindable instances still work, add exception handler for
UnsupportedOperationException to ServiceInstanceBindingController.

Issue: #90