### PR TITLE
Move all exception handling to a ControllerAdvice class.

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerWebMvcAutoConfiguration.java
@@ -21,8 +21,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
-import org.springframework.cloud.servicebroker.autoconfigure.web.ServiceBrokerAutoConfiguration;
 import org.springframework.cloud.servicebroker.controller.CatalogController;
+import org.springframework.cloud.servicebroker.controller.ServiceBrokerExceptionHandler;
 import org.springframework.cloud.servicebroker.controller.ServiceInstanceBindingController;
 import org.springframework.cloud.servicebroker.controller.ServiceInstanceController;
 import org.springframework.cloud.servicebroker.service.CatalogService;
@@ -70,6 +70,11 @@ public class ServiceBrokerWebMvcAutoConfiguration {
 	@Bean
 	public ServiceInstanceBindingController serviceInstanceBindingController() {
 		return new ServiceInstanceBindingController(this.catalogService, this.serviceInstanceBindingService);
+	}
+
+	@Bean
+	public ServiceBrokerExceptionHandler serviceBrokerExceptionHandler() {
+		return new ServiceBrokerExceptionHandler();
 	}
 
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ApiVersionInterceptorIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ApiVersionInterceptorIntegrationTest.java
@@ -22,8 +22,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import org.springframework.cloud.servicebroker.autoconfigure.web.ApiVersionInterceptor;
 import org.springframework.cloud.servicebroker.controller.CatalogController;
+import org.springframework.cloud.servicebroker.controller.ServiceBrokerExceptionHandler;
 import org.springframework.cloud.servicebroker.model.BrokerApiVersion;
 import org.springframework.cloud.servicebroker.service.CatalogService;
 import org.springframework.http.MediaType;
@@ -92,12 +92,14 @@ public class ApiVersionInterceptorIntegrationTest {
 	private MockMvc mockWithDefaultVersion() {
 		return MockMvcBuilders.standaloneSetup(controller)
 				.addInterceptors(new ApiVersionInterceptor(new BrokerApiVersion()))
+				.setControllerAdvice(ServiceBrokerExceptionHandler.class)
 				.setMessageConverters(new MappingJackson2HttpMessageConverter()).build();
 	}
 
 	private MockMvc mockWithExpectedVersion() {
 		return MockMvcBuilders.standaloneSetup(controller)
 				.addInterceptors(new ApiVersionInterceptor(new BrokerApiVersion("expected-version")))
+				.setControllerAdvice(ServiceBrokerExceptionHandler.class)
 				.setMessageConverters(new MappingJackson2HttpMessageConverter()).build();
 	}
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/NonBindableServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/NonBindableServiceInstanceBindingControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.springframework.cloud.servicebroker.controller.ServiceBrokerExceptionHandler;
 import org.springframework.cloud.servicebroker.controller.ServiceInstanceBindingController;
 import org.springframework.cloud.servicebroker.service.NonBindableServiceInstanceBindingService;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
@@ -45,6 +46,7 @@ public class NonBindableServiceInstanceBindingControllerIntegrationTest extends 
 				new ServiceInstanceBindingController(catalogService, serviceInstanceBindingService);
 
 		this.mockMvc = MockMvcBuilders.standaloneSetup(controller)
+				.setControllerAdvice(ServiceBrokerExceptionHandler.class)
 				.setMessageConverters(new MappingJackson2HttpMessageConverter()).build();
 	}
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceBindingControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.springframework.cloud.servicebroker.controller.ServiceBrokerExceptionHandler;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerOperationInProgressException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
@@ -59,6 +60,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends AbstractSer
 	@Before
 	public void setUp() {
 		this.mockMvc = MockMvcBuilders.standaloneSetup(controller)
+				.setControllerAdvice(ServiceBrokerExceptionHandler.class)
 				.setMessageConverters(new MappingJackson2HttpMessageConverter()).build();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/ServiceBrokerRestController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/ServiceBrokerRestController.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.annotation;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RestController
+public @interface ServiceBrokerRestController {
+	@AliasFor(annotation = RestController.class)
+	String value() default "";
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
@@ -21,33 +21,16 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerApiVersionException;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerConcurrencyException;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidParametersException;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerOperationInProgressException;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerUnavailableException;
 import org.springframework.cloud.servicebroker.exception.ServiceDefinitionDoesNotExistException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
-import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
 import org.springframework.cloud.servicebroker.model.instance.AsyncServiceInstanceRequest;
 import org.springframework.cloud.servicebroker.service.CatalogService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.util.Base64Utils;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 
 /**
  * Base functionality shared by controllers.
@@ -56,9 +39,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
  * @author Scott Frederick
  */
 public class BaseController {
-
-	private static final Logger logger = LoggerFactory.getLogger(BaseController.class);
-
 	protected CatalogService catalogService;
 
 	public BaseController(CatalogService catalogService) {
@@ -130,93 +110,5 @@ public class BaseController {
 	private Map<String, Object> readJsonFromString(String value) throws IOException {
 		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 		return objectMapper.readValue(value, new TypeReference<Map<String,Object>>() {});
-	}
-
-	@ExceptionHandler(ServiceBrokerApiVersionException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerApiVersionException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.PRECONDITION_FAILED);
-	}
-
-	@ExceptionHandler(ServiceInstanceDoesNotExistException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceInstanceDoesNotExistException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
-	}
-
-	@ExceptionHandler(ServiceDefinitionDoesNotExistException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceDefinitionDoesNotExistException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
-	}
-
-	@ExceptionHandler(ServiceBrokerAsyncRequiredException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerAsyncRequiredException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
-	}
-
-	@ExceptionHandler(ServiceBrokerInvalidParametersException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerInvalidParametersException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
-	}
-
-	@ExceptionHandler(ServiceBrokerOperationInProgressException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerOperationInProgressException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.NOT_FOUND);
-	}
-
-	@ExceptionHandler(ServiceBrokerUnavailableException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerUnavailableException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.SERVICE_UNAVAILABLE);
-	}
-
-	@ExceptionHandler(ServiceBrokerConcurrencyException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerConcurrencyException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
-	}
-
-	@ExceptionHandler(ServiceBrokerException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerException ex) {
-		logger.debug("Service broker exception handled: ", ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-	}
-
-	@ExceptionHandler(HttpMessageNotReadableException.class)
-	public ResponseEntity<ErrorMessage> handleException(HttpMessageNotReadableException ex) {
-		logger.error("Unprocessable request received: ", ex);
-		return getErrorResponse(ex.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
-	}
-
-	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ErrorMessage> handleException(MethodArgumentNotValidException ex) {
-		return handleBindingException(ex, ex.getBindingResult());
-	}
-
-	private ResponseEntity<ErrorMessage> handleBindingException(Exception ex, final BindingResult result) {
-		logger.error("Unprocessable request received: ", ex);
-		StringBuilder message = new StringBuilder("Missing required fields:");
-		for (FieldError error : result.getFieldErrors()) {
-			message.append(' ').append(error.getField());
-		}
-		return getErrorResponse(message.toString(), HttpStatus.UNPROCESSABLE_ENTITY);
-	}
-
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorMessage> handleException(Exception ex) {
-		logger.error("Unknown exception handled: ", ex);
-		return getErrorResponse(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-	}
-
-	protected ResponseEntity<ErrorMessage> getErrorResponse(String message, HttpStatus status) {
-		return new ResponseEntity<>(new ErrorMessage(message), status);
-	}
-
-	protected ResponseEntity<ErrorMessage> getErrorResponse(ErrorMessage message, HttpStatus status) {
-		return new ResponseEntity<>(message, status);
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
@@ -20,11 +20,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.servicebroker.annotation.ServiceBrokerRestController;
 import org.springframework.cloud.servicebroker.model.catalog.Catalog;
 import org.springframework.cloud.servicebroker.service.CatalogService;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Provide endpoints for the catalog API.
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author sgreenberg@pivotal.io
  * @author Scott Frederick
  */
-@RestController
+@ServiceBrokerRestController
 public class CatalogController extends BaseController {
 
 	private static final Logger logger = LoggerFactory.getLogger(CatalogController.class);

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -33,6 +33,8 @@ import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotE
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
 import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
@@ -50,6 +52,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  */
 @ControllerAdvice(annotations = ServiceBrokerRestController.class)
 @ResponseBody
+@Order(Ordered.LOWEST_PRECEDENCE - 10)
 public class ServiceBrokerExceptionHandler {
 	private static final Logger logger = LoggerFactory.getLogger(ServiceBrokerExceptionHandler.class);
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.servicebroker.annotation.ServiceBrokerRestController;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerApiVersionException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerBindingRequiresAppException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerConcurrencyException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidParametersException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerOperationInProgressException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerUnavailableException;
+import org.springframework.cloud.servicebroker.exception.ServiceDefinitionDoesNotExistException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
+import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception handling logic shared by all Controllers.
+ *
+ * @author Scott Frederick
+ */
+@ControllerAdvice(annotations = ServiceBrokerRestController.class)
+@ResponseBody
+public class ServiceBrokerExceptionHandler {
+	private static final Logger logger = LoggerFactory.getLogger(ServiceBrokerExceptionHandler.class);
+
+	@ExceptionHandler(ServiceBrokerApiVersionException.class)
+	@ResponseStatus(HttpStatus.PRECONDITION_FAILED)
+	public ErrorMessage handleException(ServiceBrokerApiVersionException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceInstanceDoesNotExistException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceInstanceDoesNotExistException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceDefinitionDoesNotExistException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceDefinitionDoesNotExistException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceBrokerAsyncRequiredException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceBrokerAsyncRequiredException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceBrokerInvalidParametersException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceBrokerInvalidParametersException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceBrokerOperationInProgressException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public ErrorMessage handleException(ServiceBrokerOperationInProgressException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceBrokerUnavailableException.class)
+	@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+	public ErrorMessage handleException(ServiceBrokerUnavailableException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceBrokerConcurrencyException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceBrokerConcurrencyException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceBrokerException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	public ErrorMessage handleException(ServiceBrokerException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(HttpMessageNotReadableException ex) {
+		logger.error("Unprocessable request received: ", ex);
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(MethodArgumentNotValidException ex) {
+		return handleBindingException(ex, ex.getBindingResult());
+	}
+
+	private ErrorMessage handleBindingException(Exception ex, final BindingResult result) {
+		logger.error("Unprocessable request received: ", ex);
+		StringBuilder message = new StringBuilder("Missing required fields:");
+		for (FieldError error : result.getFieldErrors()) {
+			message.append(' ').append(error.getField());
+		}
+		return getErrorResponse(message.toString());
+	}
+
+	@ExceptionHandler(Exception.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	public ErrorMessage handleException(Exception ex) {
+		logger.error("Unknown exception handled: ", ex);
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceInstanceExistsException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorMessage handleException(ServiceInstanceExistsException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceInstanceUpdateNotSupportedException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceInstanceUpdateNotSupportedException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceInstanceBindingExistsException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorMessage handleException(ServiceInstanceBindingExistsException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceBrokerBindingRequiresAppException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceBrokerBindingRequiresAppException ex) {
+		return getErrorResponse(ex);
+	}
+
+	protected ErrorMessage getErrorResponse(ServiceBrokerException ex) {
+		logger.debug(ex.getMessage(), ex);
+		return ex.getErrorMessage();
+	}
+
+	protected ErrorMessage getErrorResponse(Exception ex) {
+		return getErrorResponse(ex.getMessage());
+	}
+
+	protected ErrorMessage getErrorResponse(String message) {
+		return new ErrorMessage(message);
+	}
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -24,29 +24,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerBindingRequiresAppException;
+import org.springframework.cloud.servicebroker.annotation.ServiceBrokerRestController;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingResponse;
 import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingResponse;
-import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
 import org.springframework.cloud.servicebroker.service.CatalogService;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Provide endpoints for the service bindings API.
@@ -56,7 +52,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author sgreenberg@pivotal.io
  * @author Scott Frederick
  */
-@RestController
+@ServiceBrokerRestController
 public class ServiceInstanceBindingController extends BaseController {
 
 	private static final Logger logger = LoggerFactory.getLogger(ServiceInstanceBindingController.class);
@@ -165,17 +161,5 @@ public class ServiceInstanceBindingController extends BaseController {
 		logger.debug("Deleting a service instance binding succeeded: bindingId={}", bindingId);
 
 		return new ResponseEntity<>("{}", HttpStatus.OK);
-	}
-
-	@ExceptionHandler(ServiceInstanceBindingExistsException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceInstanceBindingExistsException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.CONFLICT);
-	}
-
-	@ExceptionHandler(ServiceBrokerBindingRequiresAppException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerBindingRequiresAppException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
@@ -23,12 +23,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.servicebroker.annotation.ServiceBrokerRestController;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
 import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
-import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
 import org.springframework.cloud.servicebroker.model.instance.AsyncServiceInstanceRequest;
 import org.springframework.cloud.servicebroker.model.instance.AsyncServiceInstanceResponse;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
@@ -47,7 +45,6 @@ import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -55,7 +52,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Provide endpoints for the service instances API.
@@ -65,7 +61,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author sgreenberg@pivotal.io
  * @author Scott Frederick
  */
-@RestController
+@ServiceBrokerRestController
 public class ServiceInstanceController extends BaseController {
 
 	private static final Logger logger = LoggerFactory.getLogger(ServiceInstanceController.class);
@@ -250,17 +246,5 @@ public class ServiceInstanceController extends BaseController {
 			return HttpStatus.ACCEPTED;
 		}
 		return HttpStatus.OK;
-	}
-
-	@ExceptionHandler(ServiceInstanceExistsException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceInstanceExistsException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.CONFLICT);
-	}
-
-	@ExceptionHandler(ServiceInstanceUpdateNotSupportedException.class)
-	public ResponseEntity<ErrorMessage> handleException(ServiceInstanceUpdateNotSupportedException ex) {
-		logger.debug(ex.getMessage(), ex);
-		return getErrorResponse(ex.getErrorMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.controller;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerApiVersionException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerBindingRequiresAppException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerConcurrencyException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidParametersException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerOperationInProgressException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerUnavailableException;
+import org.springframework.cloud.servicebroker.exception.ServiceDefinitionDoesNotExistException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
+import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.MapBindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException.ASYNC_REQUIRED_ERROR;
+import static org.springframework.cloud.servicebroker.exception.ServiceBrokerBindingRequiresAppException.APP_REQUIRED_ERROR;
+import static org.springframework.cloud.servicebroker.exception.ServiceBrokerConcurrencyException.CONCURRENCY_ERROR;
+
+public class ServiceBrokerExceptionHandlerTest {
+	private ServiceBrokerExceptionHandler exceptionHandler;
+
+	@Before
+	public void setUp() {
+		exceptionHandler = new ServiceBrokerExceptionHandler();
+	}
+
+	@Test
+	public void serviceBrokerApiVersionException() {
+		ServiceBrokerApiVersionException exception =
+				new ServiceBrokerApiVersionException("expected-version", "actual-version");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("expected version=expected-version");
+		assertThat(errorMessage.getMessage()).contains("provided version=actual-version");
+	}
+
+	@Test
+	public void serviceInstanceDoesNotExistException() {
+		ServiceInstanceDoesNotExistException exception =
+				new ServiceInstanceDoesNotExistException("service-instance-id");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("id=service-instance-id");
+	}
+
+	@Test
+	public void serviceDefinitionDoesNotExistException() {
+		ServiceDefinitionDoesNotExistException exception =
+				new ServiceDefinitionDoesNotExistException("service-definition-id");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("id=service-definition-id");
+	}
+
+	@Test
+	public void serviceBrokerAsyncRequiredException() {
+		ServiceBrokerAsyncRequiredException exception =
+				new ServiceBrokerAsyncRequiredException("test message");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isEqualTo(ASYNC_REQUIRED_ERROR);
+		assertThat(errorMessage.getMessage()).contains("test message");
+	}
+
+	@Test
+	public void serviceBrokerInvalidParametersException() {
+		ServiceBrokerInvalidParametersException exception =
+				new ServiceBrokerInvalidParametersException("test message");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("test message");
+	}
+
+	@Test
+	public void httpMessageNotReadableException() {
+		HttpMessageNotReadableException exception =
+				new HttpMessageNotReadableException("test message");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("test message");
+	}
+
+	@Test
+	public void operationInProgressException() {
+		ServiceBrokerOperationInProgressException exception =
+				new ServiceBrokerOperationInProgressException("still working");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("still working");
+	}
+
+	@Test
+	public void serviceBrokerUnavailableException() {
+		ServiceBrokerUnavailableException exception = new ServiceBrokerUnavailableException("maintenance in progress");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("maintenance in progress");
+	}
+
+	@Test
+	public void serviceBrokerConcurrencyException() {
+		ServiceBrokerConcurrencyException exception = new ServiceBrokerConcurrencyException("operation in progress");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isEqualTo(CONCURRENCY_ERROR);
+		assertThat(errorMessage.getMessage()).contains("operation in progress");
+	}
+
+	@Test
+	public void serviceBrokerException() {
+		ServiceBrokerException exception = new ServiceBrokerException("test message");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("test message");
+	}
+
+	@Test
+	public void serviceBrokerExceptionWithErrorCode() {
+		ServiceBrokerException exception = new ServiceBrokerException("ErrorCode", "test message");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isEqualTo("ErrorCode");
+		assertThat(errorMessage.getMessage()).contains("test message");
+	}
+
+	@Test
+	public void unknownException() {
+		Exception exception = new Exception("test message");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("test message");
+	}
+
+	@Test
+	public void methodArgumentNotValidException() throws NoSuchMethodException {
+		BindingResult bindingResult = new MapBindingResult(new HashMap<>(), "objectName");
+		bindingResult.addError(new FieldError("objectName", "field1", "message"));
+		bindingResult.addError(new FieldError("objectName", "field2", "message"));
+
+		Method method = this.getClass().getMethod("setUp", (Class<?>[]) null);
+		MethodParameter parameter = new MethodParameter(method, -1);
+		
+		MethodArgumentNotValidException exception =
+				new MethodArgumentNotValidException(parameter, bindingResult);
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains("field1");
+		assertThat(errorMessage.getMessage()).contains("field2");
+	}
+
+	@Test
+	public void serviceInstanceExistsException() {
+		ServiceInstanceExistsException exception =
+				new ServiceInstanceExistsException("service-instance-id", "service-definition-id");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getMessage()).contains("serviceInstanceId=service-instance-id");
+		assertThat(errorMessage.getMessage()).contains("serviceDefinitionId=service-definition-id");
+	}
+
+	@Test
+	public void serviceInstanceUpdateNotSupportedException() {
+		ServiceInstanceUpdateNotSupportedException exception = new
+				ServiceInstanceUpdateNotSupportedException("test exception");
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getMessage()).contains("test exception");
+	}
+
+	@Test
+	public void bindingExistsException() {
+		ErrorMessage errorMessage = exceptionHandler
+				.handleException(new ServiceInstanceBindingExistsException("service-instance-id", "binding-id"));
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage())
+				.contains("serviceInstanceId=service-instance-id")
+				.contains("bindingId=binding-id");
+	}
+
+	@Test
+	public void appRequiredException() {
+		ErrorMessage errorMessage = exceptionHandler
+				.handleException(new ServiceBrokerBindingRequiresAppException("app GUID is required"));
+
+		assertThat(errorMessage.getError()).isEqualTo(APP_REQUIRED_ERROR);
+		assertThat(errorMessage.getMessage()).contains("app GUID is required");
+	}
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
@@ -22,9 +22,7 @@ import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerBindingRequiresAppException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingResponse;
@@ -32,7 +30,6 @@ import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstan
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingResponse;
-import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 import org.springframework.cloud.servicebroker.service.CatalogService;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
@@ -51,7 +48,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.cloud.servicebroker.exception.ServiceBrokerBindingRequiresAppException.APP_REQUIRED_ERROR;
 
 @RunWith(Theories.class)
 public class ServiceInstanceBindingControllerResponseCodeTest {
@@ -157,28 +153,6 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.GONE);
 		assertThat(responseEntity.getBody()).isEqualTo("{}");
-	}
-
-	@Test
-	public void bindingExistsGivesExpectedStatus() {
-		ResponseEntity<ErrorMessage> responseEntity = controller
-				.handleException(new ServiceInstanceBindingExistsException("service-instance-id", "binding-id"));
-
-		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
-		assertThat(responseEntity.getBody().getError()).isNull();
-		assertThat(responseEntity.getBody().getMessage())
-				.contains("serviceInstanceId=service-instance-id")
-				.contains("bindingId=binding-id");
-	}
-
-	@Test
-	public void appRequiredExistsGivesExpectedStatus() {
-		ResponseEntity<ErrorMessage> responseEntity = controller
-				.handleException(new ServiceBrokerBindingRequiresAppException("app GUID is required"));
-
-		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
-		assertThat(responseEntity.getBody().getError()).isEqualTo(APP_REQUIRED_ERROR);
-		assertThat(responseEntity.getBody().getMessage()).contains("app GUID is required");
 	}
 
 	public static class CreateResponseAndExpectedStatus {

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
@@ -23,14 +23,11 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
 import org.springframework.cloud.servicebroker.model.instance.AsyncServiceInstanceResponse;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceResponse;
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceResponse;
-import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
 import org.springframework.cloud.servicebroker.model.instance.GetLastServiceOperationRequest;
 import org.springframework.cloud.servicebroker.model.instance.GetLastServiceOperationResponse;
 import org.springframework.cloud.servicebroker.model.instance.GetServiceInstanceRequest;
@@ -289,29 +286,6 @@ public class ServiceInstanceControllerResponseCodeTest {
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(data.expectedStatus);
 		assertThat(responseEntity.getBody()).isEqualTo(data.response);
-	}
-
-	@Test
-	public void serviceInstanceExistsExceptionGivesExpectedStatus() {
-		ServiceInstanceExistsException exception =
-				new ServiceInstanceExistsException("service-instance-id", "service-definition-id");
-
-		ResponseEntity<ErrorMessage> responseEntity = controller.handleException(exception);
-
-		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
-		assertThat(responseEntity.getBody().getMessage()).contains("serviceInstanceId=service-instance-id");
-		assertThat(responseEntity.getBody().getMessage()).contains("serviceDefinitionId=service-definition-id");
-	}
-
-	@Test
-	public void serviceInstanceUpdateNotSupportedExceptionGivesExpectedStatus() {
-		ServiceInstanceUpdateNotSupportedException exception = new
-				ServiceInstanceUpdateNotSupportedException("test exception");
-
-		ResponseEntity<ErrorMessage> responseEntity = controller.handleException(exception);
-
-		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
-		assertThat(responseEntity.getBody().getMessage()).contains("test exception");
 	}
 
 	public static class AsyncResponseAndExpectedStatus<T extends AsyncServiceInstanceResponse> {


### PR DESCRIPTION
This change moves all exception handling logic from `@Controller` classes to a `@ControllerAdvice` class. This should make it easier for users to add their own additional exception handling as suggested in #90. It has the additional benefit of making Controller classes easier to read by separating concerns, and making the exception handling methods more declarative with the use of `@ResponseStatus`. 