### PR TITLE
Rationalize Context subclassing

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
@@ -23,7 +23,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.cloud.servicebroker.exception.ServiceDefinitionDoesNotExistException;
+import org.springframework.cloud.servicebroker.model.CloudFoundryContext;
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.KubernetesContext;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 import org.springframework.cloud.servicebroker.model.instance.AsyncServiceInstanceRequest;
@@ -31,6 +34,9 @@ import org.springframework.cloud.servicebroker.service.CatalogService;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.util.Base64Utils;
+
+import static org.springframework.cloud.servicebroker.model.CloudFoundryContext.CLOUD_FOUNDRY_PLATFORM;
+import static org.springframework.cloud.servicebroker.model.KubernetesContext.KUBERNETES_PLATFORM;
 
 /**
  * Base functionality shared by controllers.
@@ -101,10 +107,20 @@ public class BaseController {
 
 		String platform = parts[0];
 
-		return Context.builder()
-				.platform(platform)
-				.properties(properties)
-				.build();
+		if (CLOUD_FOUNDRY_PLATFORM.equals(platform)) {
+			return CloudFoundryContext.builder()
+					.properties(properties)
+					.build();
+		} else if (KUBERNETES_PLATFORM.equals(platform)) {
+			return KubernetesContext.builder()
+					.properties(properties)
+					.build();
+		} else {
+			return PlatformContext.builder()
+					.platform(platform)
+					.properties(properties)
+					.build();
+		}
 	}
 
 	private Map<String, Object> readJsonFromString(String value) throws IOException {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
@@ -34,14 +34,18 @@ public final class CloudFoundryContext extends Context {
 	public static final String ORGANIZATION_GUID_KEY = "organizationGuid";
 	public static final String SPACE_GUID_KEY = "spaceGuid";
 
-	CloudFoundryContext() {
+	private CloudFoundryContext() {
 		super(CLOUD_FOUNDRY_PLATFORM, null);
 	}
 
-	CloudFoundryContext(String organizationGuid, String spaceGuid, Map<String, Object> properties) {
+	private CloudFoundryContext(String organizationGuid, String spaceGuid, Map<String, Object> properties) {
 		super(CLOUD_FOUNDRY_PLATFORM, properties);
-		setOrganizationGuid(organizationGuid);
-		setSpaceGuid(spaceGuid);
+		if (organizationGuid != null) {
+			setOrganizationGuid(organizationGuid);
+		}
+		if (spaceGuid != null) {
+			setSpaceGuid(spaceGuid);
+		}
 	}
 
 	public String getOrganizationGuid() {
@@ -62,5 +66,36 @@ public final class CloudFoundryContext extends Context {
 	@NotEmpty
 	private void setSpaceGuid(String spaceGuid) {
 		properties.put(SPACE_GUID_KEY, spaceGuid);
+	}
+
+	public static CloudFoundryContextBuilder builder() {
+		return new CloudFoundryContextBuilder();
+	}
+
+	public static class CloudFoundryContextBuilder extends ContextBaseBuilder<CloudFoundryContext, CloudFoundryContextBuilder> {
+		private String organizationGuid;
+		private String spaceGuid;
+
+		CloudFoundryContextBuilder() {
+		}
+
+		@Override
+		protected CloudFoundryContextBuilder createBuilder() {
+			return this;
+		}
+
+		public CloudFoundryContextBuilder organizationGuid(String organizationGuid) {
+			this.organizationGuid = organizationGuid;
+			return this;
+		}
+
+		public CloudFoundryContextBuilder spaceGuid(String spaceGuid) {
+			this.spaceGuid = spaceGuid;
+			return this;
+		}
+
+		public CloudFoundryContext build() {
+			return new CloudFoundryContext(organizationGuid, spaceGuid, properties);
+		}
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
@@ -17,9 +17,9 @@
 package org.springframework.cloud.servicebroker.model;
 
 import java.util.Map;
-import java.util.Objects;
 import javax.validation.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -31,66 +31,36 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public final class CloudFoundryContext extends Context {
 	public static final String CLOUD_FOUNDRY_PLATFORM = "cloudfoundry";
+	public static final String ORGANIZATION_GUID_KEY = "organizationGuid";
+	public static final String SPACE_GUID_KEY = "spaceGuid";
 
-	/**
-	 * The Cloud Controller GUID of the organization for which the operation is requested.
-	 */
-	@NotEmpty
-	private final String organizationGuid;
-
-	/**
-	 * The Cloud Controller GUID of the space for which the operation is requested.
-	 */
-	@NotEmpty
-	private final String spaceGuid;
-
-	private CloudFoundryContext() {
+	CloudFoundryContext() {
 		super(CLOUD_FOUNDRY_PLATFORM, null);
-		this.organizationGuid = null;
-		this.spaceGuid = null;
 	}
 
-	private CloudFoundryContext(String organizationGuid, String spaceGuid, Map<String, Object> properties) {
+	CloudFoundryContext(String organizationGuid, String spaceGuid, Map<String, Object> properties) {
 		super(CLOUD_FOUNDRY_PLATFORM, properties);
-		this.organizationGuid = organizationGuid;
-		this.spaceGuid = spaceGuid;
+		setOrganizationGuid(organizationGuid);
+		setSpaceGuid(spaceGuid);
 	}
 
 	public String getOrganizationGuid() {
-		return this.organizationGuid;
+		return getStringProperty(ORGANIZATION_GUID_KEY);
+	}
+
+	@JsonProperty
+	@NotEmpty
+	private void setOrganizationGuid(String organizationGuid) {
+		properties.put(ORGANIZATION_GUID_KEY, organizationGuid);
 	}
 
 	public String getSpaceGuid() {
-		return this.spaceGuid;
+		return getStringProperty(SPACE_GUID_KEY);
 	}
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (!(o instanceof CloudFoundryContext)) return false;
-		if (!super.equals(o)) return false;
-		CloudFoundryContext that = (CloudFoundryContext) o;
-		return that.canEqual(this) &&
-				Objects.equals(organizationGuid, that.organizationGuid) &&
-				Objects.equals(spaceGuid, that.spaceGuid);
-	}
-
-	@Override
-	public boolean canEqual(Object other) {
-		return (other instanceof CloudFoundryContext);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), organizationGuid, spaceGuid);
-	}
-
-	@Override
-	public String toString() {
-		return super.toString() +
-				"CloudFoundryContext{" +
-				"organizationGuid='" + organizationGuid + '\'' +
-				", spaceGuid='" + spaceGuid + '\'' +
-				'}';
+	@JsonProperty
+	@NotEmpty
+	private void setSpaceGuid(String spaceGuid) {
+		properties.put(SPACE_GUID_KEY, spaceGuid);
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
@@ -45,7 +45,7 @@ public class Context {
 	private final String platform;
 
 	@JsonAnySetter
-	private final Map<String, Object> properties = new HashMap<>();
+	protected final Map<String, Object> properties = new HashMap<>();
 
 	protected Context() {
 		this.platform = null;
@@ -77,8 +77,15 @@ public class Context {
 		return this.properties.get(key);
 	}
 
+	protected String getStringProperty(String key) {
+		if (properties.containsKey(key)) {
+			return getProperty(key).toString();
+		}
+		return null;
+	}
+
 	@Override
-	public boolean equals(Object o) {
+	public final boolean equals(Object o) {
 		if (this == o) return true;
 		if (!(o instanceof Context)) return false;
 		Context that = (Context) o;
@@ -87,17 +94,17 @@ public class Context {
 				Objects.equals(properties, that.properties);
 	}
 
-	public boolean canEqual(Object other) {
+	public final boolean canEqual(Object other) {
 		return (other instanceof Context);
 	}
 
 	@Override
-	public int hashCode() {
+	public final int hashCode() {
 		return Objects.hash(platform, properties);
 	}
 
 	@Override
-	public String toString() {
+	public final String toString() {
 		return "Context{" +
 				"platform='" + platform + '\'' +
 				", properties=" + properties +

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
@@ -16,7 +16,8 @@
 
 package org.springframework.cloud.servicebroker.model;
 
-import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.validation.constraints.NotEmpty;
 
 /**
@@ -26,49 +27,22 @@ import javax.validation.constraints.NotEmpty;
  */
 public final class KubernetesContext extends Context {
 	public static final String KUBERNETES_PLATFORM = "kubernetes";
+	public static final String NAMESPACE_KEY = "namespace";
 
-	/**
-	 * The Kubernetes namespace for which the operation is requested.
-	 */
-	@NotEmpty
-	private final String namespace;
-
-	private KubernetesContext() {
-		this.namespace = null;
+	KubernetesContext() {
 	}
 
-	private KubernetesContext(String namespace) {
-		this.namespace = namespace;
+	KubernetesContext(String namespace) {
+		setNamespace(namespace);
 	}
 
 	public String getNamespace() {
-		return this.namespace;
+		return getStringProperty(NAMESPACE_KEY);
 	}
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (!(o instanceof KubernetesContext)) return false;
-		if (!super.equals(o)) return false;
-		KubernetesContext that = (KubernetesContext) o;
-		return Objects.equals(namespace, that.namespace);
-	}
-
-	@Override
-	public boolean canEqual(Object other) {
-		return (other instanceof KubernetesContext);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), namespace);
-	}
-
-	@Override
-	public String toString() {
-		return super.toString() +
-				"KubernetesContext{" +
-				"namespace='" + namespace + '\'' +
-				'}';
+	@JsonProperty
+	@NotEmpty
+	private void setNamespace(String namespace) {
+		properties.put(NAMESPACE_KEY, namespace);
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.servicebroker.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.Map;
 
 /**
  * Kubernetes specific contextual information under which the service instance is to be provisioned or updated.
@@ -29,11 +30,15 @@ public final class KubernetesContext extends Context {
 	public static final String KUBERNETES_PLATFORM = "kubernetes";
 	public static final String NAMESPACE_KEY = "namespace";
 
-	KubernetesContext() {
+	private KubernetesContext() {
+		super(KUBERNETES_PLATFORM, null);
 	}
 
-	KubernetesContext(String namespace) {
-		setNamespace(namespace);
+	private KubernetesContext(String namespace, Map<String, Object> properties) {
+		super(KUBERNETES_PLATFORM, properties);
+		if (namespace != null) {
+			setNamespace(namespace);
+		}
 	}
 
 	public String getNamespace() {
@@ -45,4 +50,28 @@ public final class KubernetesContext extends Context {
 	private void setNamespace(String namespace) {
 		properties.put(NAMESPACE_KEY, namespace);
 	}
-}
+
+	public static KubernetesContextBuilder builder() {
+		return new KubernetesContextBuilder();
+	}
+
+	public static class KubernetesContextBuilder extends ContextBaseBuilder<KubernetesContext, KubernetesContextBuilder> {
+		private String namespace;
+
+		KubernetesContextBuilder() {
+		}
+
+		@Override
+		protected KubernetesContextBuilder createBuilder() {
+			return this;
+		}
+
+		public KubernetesContextBuilder namespace(String namespace) {
+			this.namespace = namespace;
+			return this;
+		}
+
+		public KubernetesContext build() {
+			return new KubernetesContext(namespace, properties);
+		}
+	}}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/PlatformContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/PlatformContext.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.model;
+
+import java.util.Map;
+
+/**
+ * Platform specific contextual information under which the service instance is to be provisioned or updated.
+ *
+ * @author Scott Frederick
+ */
+public class PlatformContext extends Context {
+
+	private PlatformContext() {
+		super(null, null);
+	}
+
+	private PlatformContext(String platform, Map<String, Object> properties) {
+		super(platform, properties);
+	}
+
+	/**
+	 * Create a builder that provides a fluent API for constructing a {@literal Context}.
+	 *
+	 * <p>
+	 * This builder is provided to support testing of service implementations.
+	 *
+	 * @return the builder
+	 */
+	public static PlatformContextBuilder builder() {
+		return new PlatformContextBuilder();
+	}
+
+	/**
+	 * Provides a fluent API for constructing a {@link PlatformContext}.
+	 */
+	public static class PlatformContextBuilder extends ContextBaseBuilder<PlatformContext, PlatformContextBuilder> {
+		PlatformContextBuilder() {
+		}
+
+		@Override
+		protected PlatformContextBuilder createBuilder() {
+			return this;
+		}
+
+		/**
+		 * Construct a {@link PlatformContext} from the provided values.
+		 *
+		 * @return the newly constructed {@literal Context}
+		 */
+		public PlatformContext build() {
+			return new PlatformContext(platform, properties);
+		}
+	}
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
@@ -20,31 +20,70 @@ import java.util.Base64;
 
 import org.junit.Test;
 
+import org.springframework.cloud.servicebroker.model.CloudFoundryContext;
+import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.KubernetesContext;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class BaseControllerTest {
+	private static final String JSON_STRING = "{" +
+			"\"key1\":\"value1\"," +
+			"\"key2\":\"value2\"" +
+			"}";
+
+	private TestBaseController controller = new TestBaseController();
+
 	@Test(expected = HttpMessageNotReadableException.class)
 	public void originatingIdentityWithNoPropertiesThrowsException() {
-		TestBaseController controller = new TestBaseController();
-
 		controller.testOriginatingIdentity("platform");
 	}
 
 	@Test(expected = HttpMessageNotReadableException.class)
 	public void originatingIdentityWithNonEncodedPropertiesThrowsException() {
-		TestBaseController controller = new TestBaseController();
-
 		controller.testOriginatingIdentity("platform some-properties");
 	}
 
 	@Test(expected = HttpMessageNotReadableException.class)
 	public void originatingIdentityWithNonJsonPropertiesThrowsException() {
-		TestBaseController controller = new TestBaseController();
-
-		String encodedProperties = Base64.getEncoder().encodeToString("some-properties".getBytes());
+		String encodedProperties = encode("some-properties");
 
 		controller.testOriginatingIdentity("platform " + encodedProperties);
+	}
+
+	@Test
+	public void originatingIdentityWithCloudFoundryPlatform() {
+		Context context = controller.testOriginatingIdentity("cloudfoundry " + encode(JSON_STRING));
+
+		assertThat(context).isInstanceOf(CloudFoundryContext.class);
+		assertThat(context.getProperty("key1")).isEqualTo("value1");
+		assertThat(context.getProperty("key2")).isEqualTo("value2");
+	}
+
+	@Test
+	public void originatingIdentityWithKubernetesPlatform() {
+		Context context = controller.testOriginatingIdentity("kubernetes " + encode(JSON_STRING));
+
+		assertThat(context).isInstanceOf(KubernetesContext.class);
+		assertThat(context.getProperty("key1")).isEqualTo("value1");
+		assertThat(context.getProperty("key2")).isEqualTo("value2");
+	}
+
+	@Test
+	public void originatingIdentityWithUnknownPlatform() {
+		Context context = controller.testOriginatingIdentity("test-platform " + encode(JSON_STRING));
+
+		assertThat(context).isInstanceOf(PlatformContext.class);
+		assertThat(context.getPlatform()).isEqualTo("test-platform");
+		assertThat(context.getProperty("key1")).isEqualTo("value1");
+		assertThat(context.getProperty("key2")).isEqualTo("value2");
+	}
+
+	private String encode(String JSON_STRING) {
+		return Base64.getEncoder().encodeToString(JSON_STRING.getBytes());
 	}
 
 	private static class TestBaseController extends BaseController {
@@ -52,11 +91,13 @@ public class BaseControllerTest {
 			super(null);
 		}
 
-		public void testOriginatingIdentity(String originatingIdentityString) {
+		public Context testOriginatingIdentity(String originatingIdentityString) {
 			ServiceBrokerRequest request = new ServiceBrokerRequest() {
 			};
 
 			setCommonRequestFields(request, "platform-instance-id", "api-info-location", originatingIdentityString);
+
+			return request.getOriginatingIdentity();
 		}
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ControllerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ControllerRequestTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -59,12 +60,12 @@ public abstract class ControllerRequestTest {
 		when(catalogService.getServiceDefinition("service-definition-id"))
 				.thenReturn(serviceDefinition);
 
-		identityContext = Context.builder()
+		identityContext = PlatformContext.builder()
 				.platform("test-platform")
 				.property("user", "user-id")
 				.build();
 
-		requestContext = Context.builder()
+		requestContext = PlatformContext.builder()
 				.platform("test-platform")
 				.property("request-property", "value")
 				.build();

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/CloudFoundryContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/CloudFoundryContextTest.java
@@ -19,25 +19,41 @@ package org.springframework.cloud.servicebroker.model;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.servicebroker.model.CloudFoundryContext.CLOUD_FOUNDRY_PLATFORM;
 import static org.springframework.cloud.servicebroker.model.CloudFoundryContext.ORGANIZATION_GUID_KEY;
 import static org.springframework.cloud.servicebroker.model.CloudFoundryContext.SPACE_GUID_KEY;
 
 public class CloudFoundryContextTest {
 	@Test
 	public void emptyContext() {
-		CloudFoundryContext context = new CloudFoundryContext();
+		CloudFoundryContext context = CloudFoundryContext.builder()
+				.build();
+
+		assertThat(context.getPlatform()).isEqualTo(CLOUD_FOUNDRY_PLATFORM);
+
 		assertThat(context.getOrganizationGuid()).isNull();
 		assertThat(context.getSpaceGuid()).isNull();
-		assertThat(context.getProperty(ORGANIZATION_GUID_KEY)).isNull();
-		assertThat(context.getProperty(SPACE_GUID_KEY)).isNull();
+
+		assertThat(context.getProperties()).isEmpty();
 	}
 
 	@Test
 	public void populatedContext() {
-		CloudFoundryContext context = new CloudFoundryContext("org-guid", "space-guid", null);
+		CloudFoundryContext context = CloudFoundryContext.builder()
+				.property("key1", "value1")
+				.organizationGuid("org-guid")
+				.spaceGuid("space-guid")
+				.property("key2", "value2")
+				.build();
+
+		assertThat(context.getPlatform()).isEqualTo(CLOUD_FOUNDRY_PLATFORM);
+
 		assertThat(context.getOrganizationGuid()).isEqualTo("org-guid");
 		assertThat(context.getSpaceGuid()).isEqualTo("space-guid");
 		assertThat(context.getProperty(ORGANIZATION_GUID_KEY)).isEqualTo("org-guid");
 		assertThat(context.getProperty(SPACE_GUID_KEY)).isEqualTo("space-guid");
+
+		assertThat(context.getProperty("key1")).isEqualTo("value1");
+		assertThat(context.getProperty("key2")).isEqualTo("value2");
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/CloudFoundryContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/CloudFoundryContextTest.java
@@ -16,16 +16,28 @@
 
 package org.springframework.cloud.servicebroker.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.servicebroker.model.CloudFoundryContext.ORGANIZATION_GUID_KEY;
+import static org.springframework.cloud.servicebroker.model.CloudFoundryContext.SPACE_GUID_KEY;
 
 public class CloudFoundryContextTest {
 	@Test
-	public void equalsAndHashCode() {
-		EqualsVerifier
-				.forClass(CloudFoundryContext.class)
-				.withRedefinedSuperclass()
-				.verify();
+	public void emptyContext() {
+		CloudFoundryContext context = new CloudFoundryContext();
+		assertThat(context.getOrganizationGuid()).isNull();
+		assertThat(context.getSpaceGuid()).isNull();
+		assertThat(context.getProperty(ORGANIZATION_GUID_KEY)).isNull();
+		assertThat(context.getProperty(SPACE_GUID_KEY)).isNull();
 	}
 
+	@Test
+	public void populatedContext() {
+		CloudFoundryContext context = new CloudFoundryContext("org-guid", "space-guid", null);
+		assertThat(context.getOrganizationGuid()).isEqualTo("org-guid");
+		assertThat(context.getSpaceGuid()).isEqualTo("space-guid");
+		assertThat(context.getProperty(ORGANIZATION_GUID_KEY)).isEqualTo("org-guid");
+		assertThat(context.getProperty(SPACE_GUID_KEY)).isEqualTo("space-guid");
+	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ContextTest.java
@@ -20,44 +20,7 @@ package org.springframework.cloud.servicebroker.model;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ContextTest {
-	@Test
-	public void contextIsBuildWithDefaults() {
-		Context context = Context.builder()
-				.build();
-
-		assertThat(context.getPlatform()).isNull();
-		assertThat(context.getProperties()).hasSize(0);
-	}
-
-	@Test
-	@SuppressWarnings("serial")
-	public void contextIsBuildWithAllValues() {
-		Map<String, Object> properties = new HashMap<String, Object>() {{
-			put("property3", "value3");
-			put("property4", true);
-		}};
-
-		Context context = Context.builder()
-				.platform("test-platform")
-				.property("property1", 1)
-				.property("property2", "value2")
-				.properties(properties)
-				.build();
-
-		assertThat(context.getPlatform()).isEqualTo("test-platform");
-		assertThat(context.getProperties()).hasSize(4);
-		assertThat(context.getProperty("property1")).isEqualTo(1);
-		assertThat(context.getProperty("property2")).isEqualTo("value2");
-		assertThat(context.getProperty("property3")).isEqualTo("value3");
-		assertThat(context.getProperty("property4")).isEqualTo(true);
-	}
-
 	@Test
 	public void equalsAndHashCode() {
 		EqualsVerifier

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ContextTest.java
@@ -62,8 +62,6 @@ public class ContextTest {
 	public void equalsAndHashCode() {
 		EqualsVerifier
 				.forClass(Context.class)
-				.withRedefinedSubclass(CloudFoundryContext.class)
-				.withRedefinedSubclass(KubernetesContext.class)
 				.verify();
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/KubernetesContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/KubernetesContextTest.java
@@ -19,20 +19,36 @@ package org.springframework.cloud.servicebroker.model;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.servicebroker.model.KubernetesContext.KUBERNETES_PLATFORM;
 import static org.springframework.cloud.servicebroker.model.KubernetesContext.NAMESPACE_KEY;
 
 public class KubernetesContextTest {
 	@Test
 	public void emptyContext() {
-		KubernetesContext context = new KubernetesContext();
+		KubernetesContext context = KubernetesContext.builder()
+				.build();
+
+		assertThat(context.getPlatform()).isEqualTo(KUBERNETES_PLATFORM);
+
 		assertThat(context.getNamespace()).isNull();
-		assertThat(context.getProperty(NAMESPACE_KEY)).isNull();
+
+		assertThat(context.getProperties()).isEmpty();
 	}
 
 	@Test
 	public void populatedContext() {
-		KubernetesContext context = new KubernetesContext("namespace");
+		KubernetesContext context = KubernetesContext.builder()
+				.property("key1", "value1")
+				.namespace("namespace")
+				.property("key2", "value2")
+				.build();
+
+		assertThat(context.getPlatform()).isEqualTo(KUBERNETES_PLATFORM);
+
 		assertThat(context.getNamespace()).isEqualTo("namespace");
 		assertThat(context.getProperty(NAMESPACE_KEY)).isEqualTo("namespace");
+
+		assertThat(context.getProperty("key1")).isEqualTo("value1");
+		assertThat(context.getProperty("key2")).isEqualTo("value2");
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/KubernetesContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/KubernetesContextTest.java
@@ -16,16 +16,23 @@
 
 package org.springframework.cloud.servicebroker.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.servicebroker.model.KubernetesContext.NAMESPACE_KEY;
 
 public class KubernetesContextTest {
 	@Test
-	public void equalsAndHashCode() {
-		EqualsVerifier
-				.forClass(KubernetesContext.class)
-				.withRedefinedSuperclass()
-				.verify();
+	public void emptyContext() {
+		KubernetesContext context = new KubernetesContext();
+		assertThat(context.getNamespace()).isNull();
+		assertThat(context.getProperty(NAMESPACE_KEY)).isNull();
 	}
 
+	@Test
+	public void populatedContext() {
+		KubernetesContext context = new KubernetesContext("namespace");
+		assertThat(context.getNamespace()).isEqualTo("namespace");
+		assertThat(context.getProperty(NAMESPACE_KEY)).isEqualTo("namespace");
+	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/PlatformContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/PlatformContextTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.model;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlatformContextTest {
+	@Test
+	public void contextIsBuildWithDefaults() {
+		PlatformContext context = PlatformContext.builder()
+				.build();
+
+		assertThat(context.getPlatform()).isNull();
+		assertThat(context.getProperties()).hasSize(0);
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	public void contextIsBuildWithAllValues() {
+		Map<String, Object> properties = new HashMap<String, Object>() {{
+			put("property3", "value3");
+			put("property4", true);
+		}};
+
+		PlatformContext context = PlatformContext.builder()
+				.platform("test-platform")
+				.property("property1", 1)
+				.property("property2", "value2")
+				.properties(properties)
+				.build();
+
+		assertThat(context.getPlatform()).isEqualTo("test-platform");
+		assertThat(context.getProperties()).hasSize(4);
+		assertThat(context.getProperty("property1")).isEqualTo(1);
+		assertThat(context.getProperty("property2")).isEqualTo("value2");
+		assertThat(context.getProperty("property3")).isEqualTo("value3");
+		assertThat(context.getProperty("property4")).isEqualTo(true);
+	}
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
@@ -21,6 +21,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.JsonUtils;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,13 +53,13 @@ public class CreateServiceInstanceBindingRequestTest {
 	@SuppressWarnings("serial")
 	public void requestWithAllValuesIsBuilt() {
 		BindResource bindResource = BindResource.builder().build();
-		Context context = Context.builder().build();
+		Context context = PlatformContext.builder().build();
 		Map<String, Object> parameters = new HashMap<String, Object>() {{
 			put("field4", "value4");
 			put("field5", "value5");
 		}};
 
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 
@@ -137,7 +138,7 @@ public class CreateServiceInstanceBindingRequestTest {
 						.properties("resource-param1", "value1")
 						.properties("resource-param2", "value2")
 						.build())
-				.context(Context.builder()
+				.context(PlatformContext.builder()
 						.platform("sample-platform")
 						.property("context-property1", "value1")
 						.property("context-property2", "value2")

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
@@ -20,6 +20,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +42,7 @@ public class DeleteServiceInstanceBindingRequestTest {
 
 	@Test
 	public void requestWithAllValuesIsBuilt() {
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
@@ -21,6 +21,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,7 +40,7 @@ public class GetServiceInstanceBindingRequestTest {
 
 	@Test
 	public void requestWithAllValuesIsBuilt() {
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
@@ -21,6 +21,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.JsonUtils;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,9 +53,9 @@ public class CreateServiceInstanceRequestTest {
 			put("field4", "value4");
 			put("field5", "value5");
 		}};
-		Context context = Context.builder().build();
+		Context context = PlatformContext.builder().build();
 
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
@@ -20,6 +20,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +43,7 @@ public class DeleteServiceInstanceRequestTest {
 	@Test
 	@SuppressWarnings("serial")
 	public void requestWithAllValuesIsBuilt() {
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
@@ -20,6 +20,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +42,7 @@ public class GetLastServiceOperationRequestTest {
 	@Test
 	@SuppressWarnings("serial")
 	public void requestWithAllValuesIsBuilt() {
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
@@ -21,6 +21,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,7 +39,7 @@ public class GetServiceInstanceRequestTest {
 
 	@Test
 	public void requestWithAllValuesIsBuilt() {
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
@@ -20,6 +20,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.Context;
+import org.springframework.cloud.servicebroker.model.PlatformContext;
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest.PreviousValues;
 import org.springframework.cloud.servicebroker.JsonUtils;
 
@@ -54,9 +55,9 @@ public class UpdateServiceInstanceRequestTest {
 			put("field4", "value4");
 			put("field5", "value5");
 		}};
-		Context context = Context.builder().build();
+		Context context = PlatformContext.builder().build();
 
-		Context originatingIdentity = Context.builder()
+		Context originatingIdentity = PlatformContext.builder()
 				.platform("test-platform")
 				.build();
 


### PR DESCRIPTION
This PR contains a few changes to how the `Context` model class and its subclasses are handled. 

1. The `CloudFoundryContext` and `KubernetesContext` types now store their parsed values in the `properties` map from their base classes instead of in fields in the subclass. This makes it possible to retrieve the values with type-specific getters or the generic `Context.getProperty()`. 
2. Builders were added for `CloudFoundryContext` and `KubernetesContext` to make it easier to write tests that mock requests from the platform. A `PlatformContext` subtype of `Context` was created with a Builder to support building contexts of a generic type. The core API of the project doesn't change, as request objects still contain a `Context` subtype. 
3. The originating identity context parsed from requests will now be built with the correct subtype. 