### PR TITLE
Ignoring dashboard url and operation when empty

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceControllerIntegrationTest.java
@@ -96,6 +96,42 @@ public class ServiceInstanceControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
+	public void createServiceInstanceResponseShouldNotContainEmptyValuesWhenNull() throws Exception {
+		setupCatalogService();
+
+		setupServiceInstanceService(CreateServiceInstanceResponse.builder()
+				.operation(null)
+				.dashboardUrl(null)
+				.build());
+
+		mockMvc.perform(put(buildCreateUpdateUrl())
+				.content(createRequestBody)
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.dashboard_url").doesNotExist())
+				.andExpect(jsonPath("$.operation").doesNotExist());
+	}
+
+	@Test
+	public void createServiceInstanceResponseShouldNotContainEmptyValuesWhenEmpty() throws Exception {
+		setupCatalogService();
+
+		setupServiceInstanceService(CreateServiceInstanceResponse.builder()
+				.operation("")
+				.dashboardUrl("")
+				.build());
+
+		mockMvc.perform(put(buildCreateUpdateUrl())
+				.content(createRequestBody)
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.dashboard_url").doesNotExist())
+				.andExpect(jsonPath("$.operation").doesNotExist());
+	}
+
+	@Test
 	public void createServiceInstanceWithEmptyPlatformInstanceIdSucceeds() throws Exception {
 		setupCatalogService();
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncServiceInstanceResponse.java
@@ -31,6 +31,7 @@ public class AsyncServiceInstanceResponse {
 	@JsonIgnore
 	protected final boolean async;
 
+	@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 	protected final String operation;
 
 	protected AsyncServiceInstanceResponse(boolean async, String operation) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.servicebroker.model.instance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -35,6 +36,7 @@ import java.util.Objects;
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class CreateServiceInstanceResponse extends AsyncServiceInstanceResponse {
+	@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 	private final String dashboardUrl;
 
 	@JsonIgnore


### PR DESCRIPTION
When `dashboard_url` and/or `operation` are an empty string they should not be included in the response.
Added test to verify that when `dashboard_url` and/or `operation` are null they are not included in the response.

Closes #109