### PR TITLE
Add service broker bad request exception to version 1.0.x

### DIFF
--- a/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerApiVersionException;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerBadRequestException;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidParametersException;
 import org.springframework.cloud.servicebroker.exception.ServiceDefinitionDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
@@ -139,6 +140,12 @@ public class BaseController {
 	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerInvalidParametersException ex) {
 		log.debug("Invalid parameters received: ", ex);
 		return getErrorResponse(ex.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
+	}
+
+	@ExceptionHandler(ServiceBrokerBadRequestException.class)
+	public ResponseEntity<ErrorMessage> handleException(ServiceBrokerBadRequestException ex) {
+		log.debug("Invalid request received: ", ex);
+		return getErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerBadRequestException.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerBadRequestException.java
@@ -1,0 +1,22 @@
+package org.springframework.cloud.servicebroker.exception;
+
+/**
+ * Thrown to indicate that request is invalid. 400 response code should be returned.
+ */
+public class ServiceBrokerBadRequestException extends RuntimeException {
+
+	private static final long serialVersionUID = 4719676639792071582L;
+
+	public ServiceBrokerBadRequestException(String message) {
+		super(message);
+	}
+
+	public ServiceBrokerBadRequestException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ServiceBrokerBadRequestException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import org.mockito.*;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerBadRequestException;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidParametersException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
@@ -247,6 +248,22 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isUnprocessableEntity())
 				.andExpect(jsonPath("$.description", is("invalid parameters description")));
+	}
+
+	@Test
+	public void createServiceInstanceWithBadRequestFails() throws Exception {
+		when(serviceInstanceService.createServiceInstance(eq(syncCreateRequest)))
+				.thenThrow(new ServiceBrokerBadRequestException("invalid request description"));
+
+		setupCatalogService(syncCreateRequest.getServiceDefinitionId());
+
+		mockMvc.perform(put(buildUrl(syncCreateRequest, false))
+				.content(DataFixture.toJson(syncCreateRequest))
+				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.description", is("invalid request description")));
 	}
 
 	@Test


### PR DESCRIPTION
In Open Service Broker API spec, there are cases that 400 response code should be returned. But currently in 1.0.x branch there is no way to return 400 response code because
- There is no predefined service broker exception which is mapped to 400 response code.
- We cannot define our own exception mapper because, in  `BaseController`, there is an exception mapper that convert `Exception` into 500.

I know that we can define custom exception mapper in version 2.x but we need to use Spring Boot 2 to use version 2.x.

This PR is to add `ServiceBrokerBadRequestException` which is mapped to 400 response code. This is a minimal change to version 1.0.x to allow to return 400 code.