### PR TITLE
Add @EnableOpenServiceBroker auto-configuration

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ApiVersionWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ApiVersionWebMvcAutoConfiguration.java
@@ -48,7 +48,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
-@ConditionalOnBean({ ServiceInstanceService.class })
+@ConditionalOnBean({ServiceBrokerConfiguration.Marker.class, ServiceInstanceService.class })
 @ConditionalOnProperty(prefix = "spring.cloud.openservicebroker", name = "api-version-check-enabled", havingValue = "true", matchIfMissing = true)
 @AutoConfigureAfter(WebMvcAutoConfiguration.class)
 @EnableConfigurationProperties(ServiceBrokerProperties.class)

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/EnableOpenServiceBroker.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/EnableOpenServiceBroker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+
+/**
+ * Add this annotation to an {@code @Configuration} class to enable the Service Broker
+ *
+ * @author Roy Clarkson
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Import(ServiceBrokerConfiguration.class)
+public @interface EnableOpenServiceBroker {
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
@@ -46,7 +46,7 @@ import org.springframework.context.annotation.Configuration;
  * @see ServiceBrokerProperties
  */
 @Configuration
-@ConditionalOnBean({ServiceInstanceService.class})
+@ConditionalOnBean({ServiceBrokerConfiguration.Marker.class, ServiceInstanceService.class})
 @EnableConfigurationProperties(ServiceBrokerProperties.class)
 public class ServiceBrokerAutoConfiguration {
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Roy Clarkson
+ */
+@Configuration
+public class ServiceBrokerConfiguration {
+
+	class Marker {}
+
+	@Bean
+	public Marker enabled() {
+		return new Marker();
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerWebMvcAutoConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Roy Clarkson
  */
 @Configuration
-@ConditionalOnBean({CatalogService.class, ServiceInstanceService.class, ServiceInstanceBindingService.class})
+@ConditionalOnBean({ServiceBrokerConfiguration.Marker.class, CatalogService.class, ServiceInstanceService.class, ServiceInstanceBindingService.class})
 @AutoConfigureAfter({WebMvcAutoConfiguration.class, ServiceBrokerAutoConfiguration.class})
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class ServiceBrokerWebMvcAutoConfiguration {

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ApiVersionWebMvcAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ApiVersionWebMvcAutoConfigurationTest.java
@@ -121,6 +121,7 @@ public class ApiVersionWebMvcAutoConfigurationTest {
 	}
 
 	@Configuration
+	@EnableOpenServiceBroker
 	public static class ServicesConfiguration {
 		@Bean
 		public ServiceInstanceService serviceInstanceService() {

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfigurationTest.java
@@ -86,9 +86,20 @@ public class ServiceBrokerAutoConfigurationTest {
 	}
 
 	@Test
+	public void servicesAreNotCreatedWithoutCatalog() {
+		this.contextRunner
+				.withUserConfiguration(MissingConfiguration.class)
+				.run(context -> {
+					assertThat(context).doesNotHaveBean(CatalogService.class);
+					assertThat(context).doesNotHaveBean(ServiceInstanceService.class);
+					assertThat(context).doesNotHaveBean(ServiceInstanceBindingService.class);
+				});
+	}
+
+	@Test
 	public void servicesAreCreatedFromCatalogProperties() {
 		this.contextRunner
-				.withUserConfiguration(NoCatalogBeanConfiguration.class)
+				.withUserConfiguration(MissingCatalogBeanConfiguration.class)
 				.withPropertyValues(
 						"spring.cloud.openservicebroker.catalog.services[0].id=service-one-id",
 						"spring.cloud.openservicebroker.catalog.services[0].name=Service One",
@@ -122,6 +133,7 @@ public class ServiceBrokerAutoConfigurationTest {
 	}
 
 	@Configuration
+	@EnableOpenServiceBroker
 	public static class CatalogBeanConfiguration {
 		@Bean
 		public Catalog catalog() {
@@ -161,11 +173,16 @@ public class ServiceBrokerAutoConfigurationTest {
 	}
 
 	@Configuration
-	public static class NoCatalogBeanConfiguration {
+	@EnableOpenServiceBroker
+	public static class MissingCatalogBeanConfiguration {
 		@Bean
 		public ServiceInstanceService serviceInstanceService() {
 			return new TestServiceInstanceService();
 		}
+	}
+
+	@Configuration
+	public static class MissingConfiguration {
 	}
 
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerWebMvcAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerWebMvcAutoConfigurationTest.java
@@ -76,6 +76,7 @@ public class ServiceBrokerWebMvcAutoConfigurationTest {
 	}
 
 	@Configuration
+	@EnableOpenServiceBroker
 	public static class FullServicesConfiguration {
 		@Bean
 		public CatalogService catalogService() {


### PR DESCRIPTION
This new annotation is required to enable controllers and configure
beans for running an open service broker application.

Resolves #133