### PR TITLE
Improve ServiceBrokerAutoConfiguration

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
@@ -17,17 +17,15 @@
 package org.springframework.cloud.servicebroker.autoconfigure.web;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.servicebroker.model.catalog.Catalog;
 import org.springframework.cloud.servicebroker.service.BeanCatalogService;
 import org.springframework.cloud.servicebroker.service.CatalogService;
-import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
 import org.springframework.cloud.servicebroker.service.NonBindableServiceInstanceBindingService;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
-import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
+import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -47,26 +45,28 @@ import org.springframework.context.annotation.Configuration;
  * @see ServiceBrokerProperties
  */
 @Configuration
-@ConditionalOnBean({ServiceInstanceService.class})
-@EnableConfigurationProperties(ServiceBrokerProperties.class)
 public class ServiceBrokerAutoConfiguration {
 
-	private final ServiceBrokerProperties serviceBrokerProperties;
-
-	public ServiceBrokerAutoConfiguration(ServiceBrokerProperties serviceBrokerProperties) {
-		this.serviceBrokerProperties = serviceBrokerProperties;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(Catalog.class)
+	@Configuration
+	@ConditionalOnMissingBean({ Catalog.class, CatalogService.class })
+	@EnableConfigurationProperties(ServiceBrokerProperties.class)
 	@ConditionalOnProperty(prefix = "spring.cloud.openservicebroker.catalog.services[0]", name = "id")
-	public Catalog catalog() {
-		return this.serviceBrokerProperties.getCatalog().toModel();
+	protected static class CatalogPropertiesMinimalConfiguration {
+
+		private final ServiceBrokerProperties serviceBrokerProperties;
+
+		public CatalogPropertiesMinimalConfiguration(ServiceBrokerProperties serviceBrokerProperties) {
+			this.serviceBrokerProperties = serviceBrokerProperties;
+		}
+
+		@Bean
+		public Catalog catalog() {
+			return this.serviceBrokerProperties.getCatalog().toModel();
+		}
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(CatalogService.class)
-	@ConditionalOnBean(Catalog.class)
 	public CatalogService beanCatalogService(Catalog catalog) {
 		return new BeanCatalogService(catalog);
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
@@ -42,8 +42,6 @@ import org.springframework.context.annotation.Configuration;
  * @author Roy Clarkson
  */
 @Configuration
-@ConditionalOnBean({ CatalogService.class, ServiceInstanceService.class,
-		ServiceInstanceBindingService.class })
 @AutoConfigureAfter({ WebFluxAutoConfiguration.class,
 		ServiceBrokerAutoConfiguration.class })
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
@@ -43,8 +43,6 @@ import org.springframework.context.annotation.Configuration;
  * @author Roy Clarkson
  */
 @Configuration
-@ConditionalOnBean({ CatalogService.class, ServiceInstanceService.class,
-		ServiceInstanceBindingService.class })
 @AutoConfigureAfter({ WebMvcAutoConfiguration.class,
 		ServiceBrokerAutoConfiguration.class })
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfigurationTest.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.cloud.servicebroker.autoconfigure.web.TestCatalogService;
@@ -33,7 +35,6 @@ import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingSer
 import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
 import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,11 +54,8 @@ public class ServiceBrokerWebFluxAutoConfigurationTest {
 	@Test
 	public void controllersAreNotCreatedWithoutRequiredServices() {
 		webApplicationContextRunner()
-				.run((context) -> {
-					assertThat(context).doesNotHaveBean(CatalogController.class);
-					assertThat(context).doesNotHaveBean(ServiceInstanceController.class);
-					assertThat(context).doesNotHaveBean(ServiceInstanceBindingController.class);
-				});
+				.run(context -> assertThat(context.getStartupFailure())
+							.isExactlyInstanceOf(UnsatisfiedDependencyException.class));
 	}
 
 	@Test
@@ -83,7 +81,7 @@ public class ServiceBrokerWebFluxAutoConfigurationTest {
 						ServiceBrokerWebMvcAutoConfiguration.class));
 	}
 
-	@Configuration
+	@TestConfiguration
 	public static class FullServicesConfiguration {
 		@Bean
 		public CatalogService catalogService() {

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfigurationTest.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.cloud.servicebroker.autoconfigure.web.TestCatalogService;
@@ -33,11 +35,11 @@ import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingSer
 import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
 import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServiceBrokerWebMvcAutoConfigurationTest {
+
 	@Test
 	public void controllersAreNotCreatedWithNonWebConfiguration() {
 		nonWebApplicationContextRunner()
@@ -52,11 +54,8 @@ public class ServiceBrokerWebMvcAutoConfigurationTest {
 	@Test
 	public void controllersAreNotCreatedWithoutRequiredServices() {
 		webApplicationContextRunner()
-				.run((context) -> {
-					assertThat(context).doesNotHaveBean(CatalogController.class);
-					assertThat(context).doesNotHaveBean(ServiceInstanceController.class);
-					assertThat(context).doesNotHaveBean(ServiceInstanceBindingController.class);
-				});
+				.run(context -> assertThat(context.getStartupFailure())
+						.isInstanceOf(UnsatisfiedDependencyException.class));
 	}
 
 	@Test
@@ -82,7 +81,7 @@ public class ServiceBrokerWebMvcAutoConfigurationTest {
 						ServiceBrokerWebFluxAutoConfiguration.class));
 	}
 
-	@Configuration
+	@TestConfiguration
 	public static class FullServicesConfiguration {
 		@Bean
 		public CatalogService catalogService() {


### PR DESCRIPTION
Add more conditionals in the auto-configuration and fail more quickly
if there any required beans that are missing.

Resolves #133