### PR TITLE
Fix Json serialization of model objects for use by OSB clients

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.Objects;
 
 /**
@@ -27,6 +29,7 @@ import java.util.Objects;
 public abstract class AsyncServiceBrokerRequest extends ServiceBrokerRequest {
 	public final static String ASYNC_REQUEST_PARAMETER = "accepts_incomplete";
 
+	@JsonIgnore //accepts_incomplete Osb field passed as query param in most subclasses
 	protected transient boolean asyncAccepted;
 
 	protected AsyncServiceBrokerRequest() {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AsyncServiceBrokerResponse {
-	@JsonIgnore
+	@JsonIgnore //not sent on the wire as json payload, but as http status instead
 	protected final boolean async;
 
 	@JsonInclude(value = JsonInclude.Include.NON_EMPTY)

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
@@ -16,9 +16,11 @@
 
 package org.springframework.cloud.servicebroker.model;
 
+import java.util.HashMap;
 import java.util.Map;
 import javax.validation.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -50,6 +52,19 @@ public final class CloudFoundryContext extends Context {
 
 	public String getOrganizationGuid() {
 		return getStringProperty(ORGANIZATION_GUID_KEY);
+	}
+
+	/**
+	 * Avoid polluting the serialized context with duplicated fields with different key
+	 * case
+	 */
+	@JsonAnyGetter
+	public Map<String, Object> getSerializableProperties() {
+		HashMap<String, Object> properties = new HashMap<>(super.getProperties());
+		properties.remove(ORGANIZATION_GUID_KEY);
+		properties.remove(SPACE_GUID_KEY);
+		properties.remove(Context.PLATFORM_KEY);
+		return properties;
 	}
 
 	@JsonProperty

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
@@ -54,12 +54,11 @@ public final class CloudFoundryContext extends Context {
 		return getStringProperty(ORGANIZATION_GUID_KEY);
 	}
 
-	/**
-	 * Avoid polluting the serialized context with duplicated fields with different key
-	 * case
-	 */
+    /**
+     * Avoid polluting the serialized context with duplicated keys
+     */
 	@JsonAnyGetter
-	public Map<String, Object> getSerializableProperties() {
+    Map<String, Object> getSerializableProperties() {
 		HashMap<String, Object> properties = new HashMap<>(super.getProperties());
 		properties.remove(ORGANIZATION_GUID_KEY);
 		properties.remove(SPACE_GUID_KEY);

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
@@ -20,10 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.*;
 
 /**
  * Platform specific contextual information under which the service instance is to be provisioned or updated. Fields
@@ -33,12 +30,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @author Scott Frederick
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY,
-		property = "platform", visible = true, defaultImpl = PlatformContext.class)
+		property = Context.PLATFORM_KEY, visible = true, defaultImpl = PlatformContext.class)
 @JsonSubTypes({
 		@JsonSubTypes.Type(value = CloudFoundryContext.class, name = CloudFoundryContext.CLOUD_FOUNDRY_PLATFORM),
 		@JsonSubTypes.Type(value = KubernetesContext.class, name = KubernetesContext.KUBERNETES_PLATFORM),
 })
 public class Context {
+	public static final String PLATFORM_KEY = "platform";
 	protected final String platform;
 
 	@JsonAnySetter
@@ -69,7 +67,7 @@ public class Context {
 	 *
 	 * @return the collection of properties
 	 */
-	@JsonAnyGetter
+	@JsonIgnore
 	public Map<String, Object> getProperties() {
 		return this.properties;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.servicebroker.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,11 +44,25 @@ public final class KubernetesContext extends Context {
 		}
 	}
 
+	@JsonProperty
 	public String getNamespace() {
 		return getStringProperty(NAMESPACE_KEY);
 	}
 
-	@JsonProperty
+	/**
+	 * Avoid polluting the serialized context with duplicated fields with different key
+	 * case
+	 */
+	@JsonAnyGetter
+	public Map<String, Object> getSerializableProperties() {
+		HashMap<String, Object> properties = new HashMap<>(super.getProperties());
+		properties.remove(KUBERNETES_PLATFORM);
+		properties.remove(NAMESPACE_KEY);
+		properties.remove(Context.PLATFORM_KEY);
+		return properties;
+	}
+
+
 	@NotEmpty
 	private void setNamespace(String namespace) {
 		properties.put(NAMESPACE_KEY, namespace);

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
@@ -50,11 +50,10 @@ public final class KubernetesContext extends Context {
 	}
 
 	/**
-	 * Avoid polluting the serialized context with duplicated fields with different key
-	 * case
+	 * Avoid polluting the serialized context with duplicated keys
 	 */
 	@JsonAnyGetter
-	public Map<String, Object> getSerializableProperties() {
+	Map<String, Object> getSerializableProperties() {
 		HashMap<String, Object> properties = new HashMap<>(super.getProperties());
 		properties.remove(KUBERNETES_PLATFORM);
 		properties.remove(NAMESPACE_KEY);

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/PlatformContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/PlatformContext.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+
 import java.util.Map;
 
 /**
@@ -31,6 +33,12 @@ public class PlatformContext extends Context {
 
 	private PlatformContext(String platform, Map<String, Object> properties) {
 		super(platform, properties);
+	}
+
+	@Override
+	@JsonAnyGetter
+	public Map<String, Object> getProperties() {
+		return super.getProperties();
 	}
 
 	/**

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.servicebroker.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -36,10 +37,13 @@ public class ServiceBrokerRequest {
 	public static final String PLAN_ID_PARAMETER = "plan_id";
 	public static final String PLATFORM_INSTANCE_ID_VARIABLE = "platformInstanceId";
 
+	@JsonIgnore //relative path to Osb query path, not to include in Json body
 	protected transient String platformInstanceId;
 
+	@JsonIgnore //mapped as X-Api-Info-Location Header
 	protected transient String apiInfoLocation;
 
+	@JsonIgnore //mapped as X-Broker-API-Originating-Identity Header
 	protected transient Context originatingIdentity;
 
 	public ServiceBrokerRequest() {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
@@ -65,6 +65,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 
 	private final BindResource bindResource;
 
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private final Map<String, Object> parameters;
 
 	private final Context context;
@@ -81,7 +82,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 		appGuid = null;
 		bindResource = null;
 		context = null;
-		parameters = null;
+		parameters = new HashMap<>();
 	}
 
 	CreateServiceInstanceBindingRequest(String serviceInstanceId, String serviceDefinitionId, String planId,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
@@ -73,6 +73,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	@JsonIgnore //internal field
 	private transient ServiceDefinition serviceDefinition;
 
+	@JsonIgnore //internal field
 	private transient Plan plan;
 
 	@SuppressWarnings("unused")

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Objects;
 import javax.validation.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.cloud.servicebroker.model.Context;
@@ -43,9 +45,12 @@ import org.springframework.cloud.servicebroker.model.util.ParameterBeanMapper;
  * @author Roy Clarkson
  */
 @SuppressWarnings({"deprecation", "DeprecatedIsStillUsed"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerRequest {
+	@JsonIgnore //Osb field passed as path param
 	private transient String serviceInstanceId;
 
+	@JsonIgnore //Osb field passed as path param
 	private transient String bindingId;
 
 	@NotEmpty
@@ -64,6 +69,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 
 	private final Context context;
 
+	@JsonIgnore //internal field
 	private transient ServiceDefinition serviceDefinition;
 
 	private transient Plan plan;

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
@@ -57,6 +57,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	@JsonIgnore /*internal field*/
 	private transient ServiceDefinition serviceDefinition;
 
+	@JsonIgnore /*internal field*/
 	private transient Plan plan;
 
 	DeleteServiceInstanceBindingRequest(String serviceInstanceId, String serviceDefinitionId, String planId,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
@@ -18,10 +18,14 @@ package org.springframework.cloud.servicebroker.model.binding;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 import org.springframework.cloud.servicebroker.model.AsyncServiceBrokerRequest;
+
+import javax.validation.constraints.NotEmpty;
 
 /**
  *  Details of a request to delete a service instance binding.
@@ -38,14 +42,19 @@ import org.springframework.cloud.servicebroker.model.AsyncServiceBrokerRequest;
  */
 public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerRequest {
 
+	@JsonIgnore // mapped as path param
 	private transient String serviceInstanceId;
 
+	@JsonIgnore // mapped as path param
 	private transient String bindingId;
 
+	@JsonProperty("service_id")
 	private transient String serviceDefinitionId;
 
+	@JsonProperty("plan_id")
 	private transient String planId;
 
+	@JsonIgnore /*internal field*/
 	private transient ServiceDefinition serviceDefinition;
 
 	private transient Plan plan;
@@ -61,6 +70,12 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 		this.bindingId = bindingId;
 		this.serviceDefinition = serviceDefinition;
 		this.plan = plan;
+	}
+
+	@JsonProperty(ASYNC_REQUEST_PARAMETER) //in base class field is excluded, as other requests are passing this as query params
+	@Override
+	public boolean isAsyncAccepted() {
+		return super.isAsyncAccepted();
 	}
 
 	/**

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
@@ -42,7 +42,6 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GetLastServiceBindingOperationResponse {
 
-	@JsonSerialize(using = ToStringSerializer.class)
 	private final OperationState state;
 
 	private final String description;

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.servicebroker.model.instance;
 import java.util.Map;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.springframework.cloud.servicebroker.model.AsyncServiceBrokerRequest;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.util.ParameterBeanMapper;
@@ -28,6 +29,7 @@ import org.springframework.cloud.servicebroker.model.util.ParameterBeanMapper;
  *
  * @author Scott Frederick
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class AsyncParameterizedServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	protected final Map<String, Object> parameters;
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.servicebroker.model.instance;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -36,7 +37,7 @@ public abstract class AsyncParameterizedServiceInstanceRequest extends AsyncServ
 	private final Context context;
 
 	protected AsyncParameterizedServiceInstanceRequest() {
-		this.parameters = null;
+		this.parameters = new HashMap<>(); // deserialize as empty map when no params in json
 		this.context = null;
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
@@ -21,11 +21,13 @@ import java.util.Map;
 import java.util.Objects;
 import javax.validation.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.springframework.cloud.servicebroker.model.CloudFoundryContext;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
@@ -54,11 +56,9 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	private final String planId;
 
 	@Deprecated
-	@JsonProperty("organization_guid")
 	private final String organizationGuid;
 
 	@Deprecated
-	@JsonProperty("space_guid")
 	private final String spaceGuid;
 
 	@JsonIgnore //mapped as path param
@@ -170,6 +170,36 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	@Deprecated
 	public String getSpaceGuid() {
 		return this.spaceGuid;
+	}
+
+	@JsonGetter("space_guid")
+	protected String getSpaceGuidToSerialize() {
+		//prefer explicitly set field if any
+		String spaceGuid = this.spaceGuid;
+		//then use cloudfoundry context if any
+		if (spaceGuid == null && getContext() instanceof CloudFoundryContext) {
+			spaceGuid = ((CloudFoundryContext) getContext()).getSpaceGuid();
+		}
+		//Otherwise, default to an arbitrary string
+		if (spaceGuid == null) {
+			spaceGuid = "default-undefined-value"; //Osb spec says "MUST be a non-empty string."
+		}
+		return spaceGuid;
+	}
+
+	@JsonGetter("organization_guid")
+	protected String getOrganizationGuidToSerialize() {
+		//prefer explicitly set field if any
+		String organizationGuid = this.organizationGuid;
+		//then use cloudfoundry context if any
+		if (organizationGuid == null && getContext() instanceof CloudFoundryContext) {
+			organizationGuid = ((CloudFoundryContext) getContext()).getOrganizationGuid();
+		}
+		//Otherwise, default to an arbitrary string
+		if (organizationGuid == null) {
+			organizationGuid = "default-undefined-value"; //Osb spec says "MUST be a non-empty string."
+		}
+		return organizationGuid;
 	}
 
 	/**

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
@@ -67,6 +67,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	@JsonIgnore /*internal field*/
 	private transient ServiceDefinition serviceDefinition;
 
+    @JsonIgnore /*internal field*/
 	private transient Plan plan;
 
 	@SuppressWarnings("unused")

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
@@ -21,8 +21,11 @@ import java.util.Map;
 import java.util.Objects;
 import javax.validation.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
@@ -47,16 +50,21 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	private final String serviceDefinitionId;
 
 	@NotEmpty
+	@JsonProperty("plan_id")
 	private final String planId;
 
 	@Deprecated
+	@JsonProperty("organization_guid")
 	private final String organizationGuid;
 
 	@Deprecated
+	@JsonProperty("space_guid")
 	private final String spaceGuid;
 
+	@JsonIgnore //mapped as path param
 	private transient String serviceInstanceId;
 
+	@JsonIgnore /*internal field*/
 	private transient ServiceDefinition serviceDefinition;
 
 	private transient Plan plan;

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
@@ -41,7 +41,7 @@ public class CreateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 	private final String dashboardUrl;
 
-	@JsonIgnore
+	@JsonIgnore //not sent on the wire as json payload, but as http status instead
 	private final boolean instanceExisted;
 
 	CreateServiceInstanceResponse(boolean async, String operation, String dashboardUrl, boolean instanceExisted) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
@@ -51,6 +51,7 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	@JsonIgnore //internal support
 	private transient ServiceDefinition serviceDefinition;
 
+	@JsonIgnore /*internal field*/
 	private transient Plan plan;
 
 	DeleteServiceInstanceRequest(String serviceInstanceId, String serviceDefinitionId,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.model.instance;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.cloud.servicebroker.model.AsyncServiceBrokerRequest;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
@@ -36,12 +38,17 @@ import java.util.Objects;
  * @author Scott Frederick
  */
 public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
+
+	@JsonIgnore //mapped as path param
 	private transient String serviceInstanceId;
 
+	@JsonProperty("service_id")
 	private transient String serviceDefinitionId;
 
+	@JsonProperty("plan_id")
 	private transient String planId;
 
+	@JsonIgnore //internal support
 	private transient ServiceDefinition serviceDefinition;
 
 	private transient Plan plan;
@@ -109,6 +116,12 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	 */
 	public ServiceDefinition getServiceDefinition() {
 		return this.serviceDefinition;
+	}
+
+	@JsonProperty(ASYNC_REQUEST_PARAMETER) //in base class field is excluded, as other requests are passing this as query params
+	@Override
+	public boolean isAsyncAccepted() {
+		return super.isAsyncAccepted();
 	}
 
 	/**

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
@@ -21,8 +21,6 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 /**
  * Details of a response to a request to get the state of the last operation on a service instance.
@@ -38,7 +36,6 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 @JsonAutoDetect
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GetLastServiceOperationResponse {
-	@JsonSerialize(using = ToStringSerializer.class)
 	private final OperationState state;
 
 	private final String description;

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/OperationState.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/OperationState.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.model.instance;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * The list of acceptable states for an operation that is being processed asynchronously.
  *
@@ -37,6 +39,7 @@ public enum OperationState {
 	 */
 	FAILED("failed");
 
+	@JsonValue
 	private final String state;
 
 	OperationState(String state) {

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/JsonUtils.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/JsonUtils.java
@@ -28,7 +28,9 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import org.springframework.cloud.servicebroker.model.Context;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public final class JsonUtils {
@@ -76,5 +78,15 @@ public final class JsonUtils {
 
 	private static Reader getTestDataFileReader(String fileName) {
 		return new BufferedReader(new InputStreamReader(JsonUtils.class.getResourceAsStream("/" + fileName)));
+	}
+
+	/**
+	 * Detect duplicate properties in json object through searching ":" in json string
+	 * (reading into a map would remove such duplicate, preventing effective duplicate detection)
+	 */
+	public static void assertThatJsonHasExactNumberOfProperties(Object object, int expectedNbProperties) {
+		//
+		String jsonString = toJson(object);
+		assertThat(jsonString.split(":")).as("extra duplicate properties in json object: " + jsonString).hasSize(1+expectedNbProperties);
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
@@ -28,6 +28,8 @@ import org.springframework.cloud.servicebroker.JsonPathAssert;
 import org.springframework.cloud.servicebroker.JsonUtils;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.PlatformContext;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.servicebroker.JsonUtils.fromJson;
@@ -200,7 +202,10 @@ public class CreateServiceInstanceBindingRequestTest {
 				.originatingIdentity(PlatformContext.builder()
 						.platform("sample-platform").build())
 				.asyncAccepted(true)
-				.serviceDefinitionId("definition-id").build();
+				.serviceDefinitionId("definition-id")
+				.serviceDefinition(ServiceDefinition.builder().build())
+				.plan(Plan.builder().build())
+				.build();
 
 		DocumentContext json = JsonUtils.toJsonPath(request);
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.servicebroker.model.binding;
 
+import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.springframework.cloud.servicebroker.JsonPathAssert;
+import org.springframework.cloud.servicebroker.JsonUtils;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.PlatformContext;
 
@@ -70,6 +73,38 @@ public class DeleteServiceInstanceBindingRequestTest {
 	}
 
 	@Test
+	@SuppressWarnings("serial")
+	public void serializesAccordingToOsbSpecs() {
+		Context originatingIdentity = PlatformContext.builder()
+				.platform("test-platform")
+				.build();
+
+		DeleteServiceInstanceBindingRequest request = DeleteServiceInstanceBindingRequest.builder()
+				.serviceInstanceId("service-instance-id")
+				.serviceDefinitionId("service-definition-id")
+				.planId("plan-id")
+				.bindingId("binding-id")
+				.asyncAccepted(true)
+				.platformInstanceId("platform-instance-id")
+				.apiInfoLocation("https://api.example.com")
+				.originatingIdentity(originatingIdentity)
+				.build();
+
+		DocumentContext json = JsonUtils.toJsonPath(request);
+
+		// 3 OSB Fields should be present
+		JsonPathAssert.assertThat(json).hasPath("$.plan_id").isEqualTo("plan-id");
+		JsonPathAssert.assertThat(json).hasPath("$.service_id").isEqualTo("service-definition-id");
+		JsonPathAssert.assertThat(json).hasPath("$.accepts_incomplete").isEqualTo(true);
+
+
+		// fields mapped outside of json body (typically http headers or request paths)
+		// should be excluded
+		JsonPathAssert.assertThat(json).hasMapAtPath("$").hasSize(3);
+
+	}
+
+		@Test
 	public void equalsAndHashCode() {
 		EqualsVerifier
 				.forClass(DeleteServiceInstanceBindingRequest.class)

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
@@ -24,6 +24,8 @@ import org.springframework.cloud.servicebroker.JsonPathAssert;
 import org.springframework.cloud.servicebroker.JsonUtils;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.PlatformContext;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,6 +90,8 @@ public class DeleteServiceInstanceBindingRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.plan(Plan.builder().build())
+				.serviceDefinition(ServiceDefinition.builder().build())
 				.build();
 
 		DocumentContext json = JsonUtils.toJsonPath(request);

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
@@ -55,6 +55,16 @@ public class PlanTest {
 		assertThat(json).hasNoPath("$.bindable");
 		assertThat(json).hasNoPath("$.metadata");
 		assertThat(json).hasNoPath("$.schemas");
+
+
+		Plan deserialized = JsonUtils.fromJson(JsonUtils.toJson(plan), Plan.class);
+		assertThat(deserialized.getId()).isEqualTo("plan-id-one");
+		assertThat(deserialized.getName()).isEqualTo("plan-one");
+		assertThat(deserialized.getDescription()).isEqualTo("Plan One");
+		assertThat(deserialized.isFree()).isEqualTo(true);
+		assertThat(deserialized.isBindable()).isNull();
+		assertThat(deserialized.getMetadata()).isEmpty(); //it's ok to not return null
+		assertThat(deserialized.getSchemas()).isNull();
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequestTest.java
@@ -82,7 +82,8 @@ public class AsyncParameterizedServiceInstanceRequestTest {
 		assertThat(request.getContext().getProperty("field1")).isEqualTo("data");
 		assertThat(request.getContext().getProperty("field2")).isEqualTo(2);
 
-		assertThat(request.getParameters()).isNull();
+		// missing parameters should result into empty response, same as in builder
+		assertThat(request.getParameters()).isEmpty();
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequestTest.java
@@ -16,9 +16,11 @@
 
 package org.springframework.cloud.servicebroker.model.instance;
 
+import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.springframework.cloud.servicebroker.JsonPathAssert;
 import org.springframework.cloud.servicebroker.model.CloudFoundryContext;
 import org.springframework.cloud.servicebroker.model.KubernetesContext;
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -81,6 +83,13 @@ public class AsyncParameterizedServiceInstanceRequestTest {
 		assertThat(request.getContext().getProperty("field2")).isEqualTo(2);
 
 		assertThat(request.getParameters()).isNull();
+	}
+
+	@Test
+	public void requestWithNoParametersIsSerializedWithoutParametersField() {
+		CreateServiceInstanceRequest request = CreateServiceInstanceRequest.builder().build();
+		DocumentContext json = JsonUtils.toJsonPath(request);
+		JsonPathAssert.assertThat(json).hasNoPath("$.parameters");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
@@ -127,12 +127,35 @@ public class CreateServiceInstanceRequestTest {
 
 		DocumentContext json = JsonUtils.toJsonPath(request);
 
-		// 4 OSB Fields should be present
+		// 6 OSB Fields should be present
 		JsonPathAssert.assertThat(json).hasPath("$.plan_id").isEqualTo("plan-id");
 		JsonPathAssert.assertThat(json).hasPath("$.service_id").isEqualTo("service-definition-id");
 		JsonPathAssert.assertThat(json).hasMapAtPath("$.parameters").hasSize(5);
 		JsonPathAssert.assertThat(json).hasPath("$.parameters.field1").isEqualTo("value1");
 		JsonPathAssert.assertThat(json).hasMapAtPath("$.context").hasSize(3);
+		JsonPathAssert.assertThat(json).hasPath("$.space_guid").isEqualTo("space-guid");
+		JsonPathAssert.assertThat(json).hasPath("$.organization_guid").isEqualTo("org-guid");
+
+
+		// fields mapped outside of json body (typically http headers or request paths)
+		// should be excluded
+		JsonPathAssert.assertThat(json).hasMapAtPath("$").hasSize(6);
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	public void serializesWithoutContextAccordingToOsbSpecs() {
+		CreateServiceInstanceRequest request = CreateServiceInstanceRequest.builder()
+				.serviceInstanceId("service-instance-id")
+				.serviceDefinitionId("service-definition-id").planId("plan-id").build();
+
+		DocumentContext json = JsonUtils.toJsonPath(request);
+
+		// 4 OSB Fields should be present
+		JsonPathAssert.assertThat(json).hasPath("$.plan_id").isEqualTo("plan-id");
+		JsonPathAssert.assertThat(json).hasPath("$.service_id").isEqualTo("service-definition-id");
+		JsonPathAssert.assertThat(json).hasPath("$.space_guid").isEqualTo("default-undefined-value");
+		JsonPathAssert.assertThat(json).hasPath("$.organization_guid").isEqualTo("default-undefined-value");
 
 
 		// fields mapped outside of json body (typically http headers or request paths)

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
@@ -25,6 +25,8 @@ import org.springframework.cloud.servicebroker.model.CloudFoundryContext;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.JsonUtils;
 import org.springframework.cloud.servicebroker.model.PlatformContext;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -114,7 +116,8 @@ public class CreateServiceInstanceRequestTest {
 
 		CreateServiceInstanceRequest request = CreateServiceInstanceRequest.builder()
 				.serviceInstanceId("service-instance-id")
-				.serviceDefinitionId("service-definition-id").planId("plan-id")
+				.serviceDefinitionId("service-definition-id")
+				.planId("plan-id")
 				.context(context)
 					.parameters("field1", "value1")
 					.parameters("field2", 2)
@@ -123,9 +126,13 @@ public class CreateServiceInstanceRequestTest {
 				.asyncAccepted(true)
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
-				.originatingIdentity(originatingIdentity).build();
+				.originatingIdentity(originatingIdentity)
+				.plan(Plan.builder().build())
+				.serviceDefinition(ServiceDefinition.builder().build())
+				.build();
 
 		DocumentContext json = JsonUtils.toJsonPath(request);
+		String jsonSerializaion = JsonUtils.toJson(request);
 
 		// 6 OSB Fields should be present
 		JsonPathAssert.assertThat(json).hasPath("$.plan_id").isEqualTo("plan-id");

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
@@ -24,6 +24,8 @@ import org.springframework.cloud.servicebroker.JsonPathAssert;
 import org.springframework.cloud.servicebroker.JsonUtils;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.PlatformContext;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,6 +86,8 @@ public class DeleteServiceInstanceRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.plan(Plan.builder().build())
+				.serviceDefinition(ServiceDefinition.builder().build())
 				.build();
 
 		DocumentContext json = JsonUtils.toJsonPath(request);
@@ -94,8 +98,6 @@ public class DeleteServiceInstanceRequestTest {
 		JsonPathAssert.assertThat(json).hasPath("$.accepts_incomplete").isEqualTo(true);
 		//Other internals should not be polluting the JSON representation
 		JsonPathAssert.assertThat(json).hasMapAtPath("$").hasSize(3);
-
-
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.servicebroker.model.instance;
 
+import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.springframework.cloud.servicebroker.JsonPathAssert;
+import org.springframework.cloud.servicebroker.JsonUtils;
 import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.PlatformContext;
 
@@ -65,6 +68,34 @@ public class DeleteServiceInstanceRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+	}
+
+	@Test
+	public void serializesAccordingToOsbSpecs() {
+		Context originatingIdentity = PlatformContext.builder()
+				.platform("test-platform")
+				.build();
+
+		DeleteServiceInstanceRequest request = DeleteServiceInstanceRequest.builder()
+				.serviceInstanceId("service-instance-id")
+				.serviceDefinitionId("service-definition-id")
+				.planId("plan-id")
+				.asyncAccepted(true)
+				.platformInstanceId("platform-instance-id")
+				.apiInfoLocation("https://api.example.com")
+				.originatingIdentity(originatingIdentity)
+				.build();
+
+		DocumentContext json = JsonUtils.toJsonPath(request);
+
+		//OSB fields
+		JsonPathAssert.assertThat(json).hasPath("$.service_id").isEqualTo("service-definition-id");
+		JsonPathAssert.assertThat(json).hasPath("$.plan_id").isEqualTo("plan-id");
+		JsonPathAssert.assertThat(json).hasPath("$.accepts_incomplete").isEqualTo(true);
+		//Other internals should not be polluting the JSON representation
+		JsonPathAssert.assertThat(json).hasMapAtPath("$").hasSize(3);
+
+
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/OperationStateTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/OperationStateTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.model.instance;
+
+import org.junit.Test;
+import org.springframework.cloud.servicebroker.JsonUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class OperationStateTest {
+
+    @Test
+    public void enumValueIsDeserialized() {
+        OperationState state = JsonUtils.readTestDataFile(
+                "operationState.json", OperationState.class);
+
+        assertThat(state).isEqualTo(OperationState.SUCCEEDED);
+    }
+
+}

--- a/spring-cloud-open-service-broker-core/src/test/resources/bindRequestWithOnlyRequiredFields.json
+++ b/spring-cloud-open-service-broker-core/src/test/resources/bindRequestWithOnlyRequiredFields.json
@@ -1,0 +1,4 @@
+{
+	"service_id": "test-service-id",
+	"plan_id": "test-plan-id"
+}

--- a/spring-cloud-open-service-broker-core/src/test/resources/getLastOperationResponse.json
+++ b/spring-cloud-open-service-broker-core/src/test/resources/getLastOperationResponse.json
@@ -1,4 +1,4 @@
 {
-  "state": "SUCCEEDED",
+  "state": "succeeded",
   "description": "description"
 }

--- a/spring-cloud-open-service-broker-core/src/test/resources/operationState.json
+++ b/spring-cloud-open-service-broker-core/src/test/resources/operationState.json
@@ -1,0 +1,1 @@
+"succeeded"


### PR DESCRIPTION
Add some prereqs for supporting an osb client (#77);
- some requests model classes serialize as Json compliant with OSB specs. 
   - covered model classes: Create** Delete**
   - not yet covered model classes: Get** Update**