### PR TITLE
Revert use of `implementation` dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ configure(allprojects) {
 	group = "org.springframework.cloud"
 
 	apply plugin: "java"
-	apply plugin: "java-library"
 	apply plugin: "eclipse"
 	apply plugin: "idea"
 	apply plugin: "jacoco"

--- a/spring-cloud-open-service-broker-autoconfigure/build.gradle
+++ b/spring-cloud-open-service-broker-autoconfigure/build.gradle
@@ -32,11 +32,12 @@ dependencyManagement {
 }
 
 dependencies {
-	implementation project(":spring-cloud-open-service-broker-core")
-	implementation("org.springframework.boot:spring-boot-starter")
+	compile project(":spring-cloud-open-service-broker-core")
+	compile("org.springframework.boot:spring-boot-starter")
+	optional("org.springframework.boot:spring-boot-starter-web")
+
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
-	optional("org.springframework.boot:spring-boot-starter-web")
 
 	testImplementation project(path: ":spring-cloud-open-service-broker-core", configuration: "testOutput")
 

--- a/spring-cloud-open-service-broker-core/build.gradle
+++ b/spring-cloud-open-service-broker-core/build.gradle
@@ -23,15 +23,14 @@ dependencyManagement {
 }
 
 dependencies {
-	implementation("org.springframework:spring-context")
+	compile("org.springframework:spring-context")
 	optional("org.springframework:spring-web")
-
-	api("com.fasterxml.jackson.core:jackson-databind:2.9.7")
-	implementation("org.hibernate.validator:hibernate-validator:6.0.13.Final")
-	implementation("commons-beanutils:commons-beanutils:1.9.3") {
+	compile("com.fasterxml.jackson.core:jackson-databind:2.9.7")
+	compile("org.hibernate.validator:hibernate-validator:6.0.13.Final")
+	compile("commons-beanutils:commons-beanutils:1.9.3") {
 		exclude group:"commons-logging", module:"commons-logging"
 	}
-	implementation("org.slf4j:slf4j-api:1.7.25")
+	compile("org.slf4j:slf4j-api:1.7.25")
 
 	testImplementation("org.springframework:spring-test") {
 		exclude group:"commons-logging", module:"commons-logging"

--- a/spring-cloud-open-service-broker-docs/build.gradle
+++ b/spring-cloud-open-service-broker-docs/build.gradle
@@ -29,10 +29,10 @@ dependencyManagement {
 apply plugin: 'org.asciidoctor.convert'
 
 dependencies {
-	implementation project(":spring-cloud-open-service-broker-core")
-	implementation("org.springframework.boot:spring-boot-starter")
-	implementation("org.springframework.boot:spring-boot-starter-security")
-	implementation("org.springframework.boot:spring-boot-starter-tomcat")
+	compile project(":spring-cloud-open-service-broker-core")
+	compile("org.springframework.boot:spring-boot-starter")
+	compile("org.springframework.boot:spring-boot-starter-security")
+	compile("org.springframework.boot:spring-boot-starter-tomcat")
 }
 
 asciidoctor {

--- a/spring-cloud-starter-open-service-broker-webmvc/build.gradle
+++ b/spring-cloud-starter-open-service-broker-webmvc/build.gradle
@@ -23,8 +23,8 @@ dependencyManagement {
 }
 
 dependencies {
-	implementation project(":spring-cloud-open-service-broker-autoconfigure")
-	implementation("org.springframework.boot:spring-boot-starter-web")
+	compile project(":spring-cloud-open-service-broker-autoconfigure")
+	compile("org.springframework.boot:spring-boot-starter-web")
 }
 
 install {


### PR DESCRIPTION
`implementation` dependencies in gradle produce `runtime` dependencies in
generated maven POMs, which is not desired for this library.

Resolves #148