### PR TITLE
Don't set default Boolean value for missing optional OSB fields

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
@@ -70,13 +70,13 @@ class Plan {
 	 * an optional field. If the value is <code>null</code>, the field will be omitted
 	 * from the serialized JSON.
 	 */
-	private Boolean bindable = false;
+	private Boolean bindable = null;
 
 	/**
 	 * Indicates whether the plan can be limited by the non_basic_services_allowed field
 	 * in a platform quota.
 	 */
-	private Boolean free = false;
+	private Boolean free = null;
 
 	public String getId() {
 		return this.id;

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceDefinition.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceDefinition.java
@@ -67,17 +67,17 @@ class ServiceDefinition {
 	 * Indicates whether the service supports requests to update instances to use a different plan from the one
 	 * used to provision a service instance.
 	 */
-	private Boolean planUpdateable = false;
+	private Boolean planUpdateable = null;
 
 	/**
 	 * Indicates whether the service broker supports retrieving service instances.
 	 */
-	private Boolean instancesRetrievable = false;
+	private Boolean instancesRetrievable = null;
 
 	/**
 	 * Indicates whether the service broker supports retrieving service bindings.
 	 */
-	private Boolean bindingsRetrievable = false;
+	private Boolean bindingsRetrievable = null;
 
 	/**
 	 * A list of tags to aid in categorizing and classifying services with similar characteristics.

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesValidationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesValidationTest.java
@@ -78,6 +78,15 @@ public class ServiceBrokerPropertiesValidationTest {
 		assertThat(catalog.getServices().get(0).getPlans().get(0).getId()).isEqualTo("plan-one-id");
 		assertThat(catalog.getServices().get(0).getPlans().get(0).getName()).isEqualTo("Plan One");
 		assertThat(catalog.getServices().get(0).getPlans().get(0).getDescription()).isEqualTo("Description for Plan One");
+
+		//Mandatory fields should have a default set when unspecified in configuration
+		assertThat(catalog.getServices().get(0).isBindable()).isNotNull();
+		//Optional unspecified fields should not have a default set.
+		assertThat(catalog.getServices().get(0).getPlans().get(0).isBindable()).isNull();
+		assertThat(catalog.getServices().get(0).getPlans().get(0).isFree()).isNull();
+		assertThat(catalog.getServices().get(0).isInstancesRetrievable()).isNull();
+		assertThat(catalog.getServices().get(0).isBindingsRetrievable()).isNull();
+		assertThat(catalog.getServices().get(0).isPlanUpdateable()).isNull();
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
@@ -272,7 +272,7 @@ public class Plan {
 		 * @param free true if the plan has no cost
 		 * @return the build instance
 		 */
-		public PlanBuilder free(boolean free) {
+		public PlanBuilder free(Boolean free) {
 			this.free = free;
 			return this;
 		}
@@ -285,7 +285,7 @@ public class Plan {
 		 * @param bindable true if the service with this plan may be bound
 		 * @return the binder instance
 		 */
-		public PlanBuilder bindable(boolean bindable) {
+		public PlanBuilder bindable(Boolean bindable) {
 			this.bindable = bindable;
 			return this;
 		}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinition.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinition.java
@@ -335,7 +335,7 @@ public class ServiceDefinition {
 		 * @param planUpdateable true if the plan may be updated
 		 * @return the binder instance
 		 */
-		public ServiceDefinitionBuilder planUpdateable(boolean planUpdateable) {
+		public ServiceDefinitionBuilder planUpdateable(Boolean planUpdateable) {
 			this.planUpdateable = planUpdateable;
 			return this;
 		}
@@ -346,7 +346,7 @@ public class ServiceDefinition {
 		 * @param instancesRetrievable true if the service instances may be retrieved
 		 * @return the binder instance
 		 */
-		public ServiceDefinitionBuilder instancesRetrievable(boolean instancesRetrievable) {
+		public ServiceDefinitionBuilder instancesRetrievable(Boolean instancesRetrievable) {
 			this.instancesRetrievable = instancesRetrievable;
 			return this;
 		}
@@ -357,7 +357,7 @@ public class ServiceDefinition {
 		 * @param bindingsRetrievable true if the service bindings may be retrieved
 		 * @return the binder instance
 		 */
-		public ServiceDefinitionBuilder bindingsRetrievable(boolean bindingsRetrievable) {
+		public ServiceDefinitionBuilder bindingsRetrievable(Boolean bindingsRetrievable) {
 			this.bindingsRetrievable = bindingsRetrievable;
 			return this;
 		}


### PR DESCRIPTION
Fixes #153

Note: here are the associated assertions in https://github.com/spring-cloud/spring-cloud-open-service-broker/blob/7e22af28656f19e79315fa96b65451f2b0d0fba0/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesValidationTest.java#L161 that reproduce the associated bug. 

```java
		Plan plan = catalog.getServices().get(1).getPlans().get(0).toModel();
		DocumentContext json = JsonUtils.toJsonPath(plan);

		JsonPathAssert.assertThat(json).hasPath("$.id").isEqualTo("plan-one-id");
		JsonPathAssert.assertThat(json).hasPath("$.name").isEqualTo("Plan One");
		JsonPathAssert.assertThat(json).hasPath("$.description").isEqualTo("Description for Plan One");
		JsonPathAssert.assertThat(json).hasNoPath("$.bindable");
		JsonPathAssert.assertThat(json).hasNoPath("$.free");
```

I felt this "integration test" was a bit outside of the ServiceBrokerPropertiesValidationTest scope so I did not include it into the PR, and focused on unit tests instead. Let me know if you believe such assertions would be useful and where to put them.