### PR TITLE
Catalog with standard cloudfoundry plan meta data

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Metadata.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Metadata.java
@@ -1,0 +1,82 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Metadata for service plans.
+ * Holds keys specified in cloudfoundry profile in OSB specs,
+ * as well as custom non-standard keys.
+ */
+public class Metadata {
+
+    private List<Cost> costs = new ArrayList<Cost>();
+
+    private List<String> bullets = new ArrayList<>();
+
+    private String displayName;
+
+    /**
+     * Custom non standard metadata need to be specified under extra hash
+     */
+    private final Map<String, Object> extra = new HashMap<>();
+
+
+    public List<Cost> getCosts() { return costs; }
+    public void setCosts(List<Cost> costs) { this.costs = costs; }
+
+    public List<String> getBullets() { return bullets; }
+
+    public void setBullets(List<String> bullets) { this.bullets = bullets; }
+
+    public String getDisplayName() { return displayName; }
+
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+
+    public Map<String, Object> getExtra() { return extra; }
+
+    public void setExtra(Map<String, Object> extra) {
+        this.extra.putAll(extra);
+    }
+
+
+    public Map<String, Object> toModel() {
+        HashMap<String, Object> model = new HashMap<>();
+        if (costs != null) {
+            model.put("costs", costs);
+        }
+        if (bullets != null) {
+            model.put("bullets", bullets);
+        }
+        if (displayName != null) {
+            model.put("displayName", displayName);
+        }
+        model.putAll(this.extra);
+        return model;
+    }
+
+    public static class Cost {
+
+        private Map<String, Double> amount = new HashMap<>();
+
+        private String unit;
+
+        public Map<String, Double> getAmount() {
+            return amount;
+        }
+
+        public void setAmount(Map<String, Double> amount) {
+            this.amount = amount;
+        }
+
+        public String getUnit() {
+            return unit;
+        }
+
+        public void setUnit(String unit) {
+            this.unit = unit;
+        }
+    }
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
@@ -55,9 +55,10 @@ class Plan {
 	private String description;
 
 	/**
-	 * A map of metadata to further describe a service plan.
+	 * The metadata for this plan
 	 */
-	private final Map<String, Object> metadata = new HashMap<>();
+	@NestedConfigurationProperty
+	private Metadata metadata;
 
 	/**
 	 * The schemas for this plan.
@@ -102,12 +103,12 @@ class Plan {
 		this.description = description;
 	}
 
-	public Map<String, Object> getMetadata() {
+	public Metadata getMetadata() {
 		return this.metadata;
 	}
 
-	public void setMetadata(Map<String, Object> metadata) {
-		this.metadata.putAll(metadata);
+	public void setMetadata(Metadata metadata) {
+		this.metadata = metadata;
 	}
 
 	public Schemas getSchemas() {
@@ -148,7 +149,7 @@ class Plan {
 				.bindable(this.bindable)
 				.free(this.free)
 				.schemas(this.schemas != null ? this.schemas.toModel() : null)
-				.metadata(this.metadata)
+				.metadata(this.metadata != null ? this.metadata.toModel() : null)
 				.build();
 	}
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesTest.java
@@ -80,8 +80,13 @@ public class ServiceBrokerPropertiesTest {
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].id", "plan-two-id");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].name", "Plan Two");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].description", "Description for Plan Two");
-		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata[key1]", "value1");
-		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata[key2]", "value2");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.extra[key1]", "value1");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.extra[key2]", "value2");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.displayName", "sample display name");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.bullets[0]", "bullet1");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.bullets[1]", "bullet2");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.costs[0].amount[usd]", "649.0");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.costs[0].unit", "MONTHLY");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].bindable", "true");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].free", "true");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].schemas.serviceinstance.create.parameters[$schema]", "http://example.com/service/create/schema");
@@ -121,7 +126,12 @@ public class ServiceBrokerPropertiesTest {
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getId()).isEqualTo("plan-two-id");
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getName()).isEqualTo("Plan Two");
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getDescription()).isEqualTo("Description for Plan Two");
-		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getMetadata()).containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getMetadata().getExtra()).containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getMetadata().getBullets()).contains("bullet1", "bullet2");
+		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getMetadata().getCosts()).hasSize(1);
+		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getMetadata().getCosts().get(0).getAmount().get("usd")).isEqualTo(649.0d);
+		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getMetadata().getCosts().get(0).getUnit()).isEqualTo("MONTHLY");
+
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).isBindable()).isTrue();
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).isFree()).isTrue();
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getSchemas().getServiceInstance().getCreate().getParameters())
@@ -158,7 +168,9 @@ public class ServiceBrokerPropertiesTest {
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getId()).isEqualTo("plan-two-id");
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getName()).isEqualTo("Plan Two");
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getDescription()).isEqualTo("Description for Plan Two");
-		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getMetadata()).containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getMetadata()).contains(entry("key1", "value1"), entry("key2", "value2"), entry("displayName", "sample display name"));
+		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getMetadata().get("costs")).isNotNull();
+		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getMetadata().get("bullets")).isNotNull();
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).isBindable()).isTrue();
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).isFree()).isTrue();
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getSchemas().getServiceInstanceSchema().getCreateMethodSchema().getParameters())

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesValidationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesValidationTest.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.servicebroker.autoconfigure.web;
 
 import java.util.List;
 
+import com.jayway.jsonpath.DocumentContext;
+import org.assertj.core.data.MapEntry;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,6 +29,8 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.env.YamlPropertySourceLoader;
 import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.cloud.servicebroker.JsonPathAssert;
+import org.springframework.cloud.servicebroker.JsonUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.PropertySource;
@@ -134,7 +138,12 @@ public class ServiceBrokerPropertiesValidationTest {
 		assertThat(catalog.getServices().get(0).getPlans().get(1).getId()).isEqualTo("plan-two-id");
 		assertThat(catalog.getServices().get(0).getPlans().get(1).getName()).isEqualTo("Plan Two");
 		assertThat(catalog.getServices().get(0).getPlans().get(1).getDescription()).isEqualTo("Description for Plan Two");
-		assertThat(catalog.getServices().get(0).getPlans().get(1).getMetadata()).containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+		assertThat(catalog.getServices().get(0).getPlans().get(1).getMetadata().getExtra()).containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+		assertThat(catalog.getServices().get(0).getPlans().get(1).getMetadata().getCosts()).hasSize(1);
+		assertThat(catalog.getServices().get(0).getPlans().get(1).getMetadata().getCosts().get(0).getUnit()).isEqualTo("MONTHLY");
+		assertThat(catalog.getServices().get(0).getPlans().get(1).getMetadata().getCosts().get(0).getAmount()).contains(entry("usd", 649.0));
+		assertThat(catalog.getServices().get(0).getPlans().get(1).getMetadata().getDisplayName()).isEqualTo("sample display name");
+		assertThat(catalog.getServices().get(0).getPlans().get(1).getMetadata().getBullets()).containsExactlyInAnyOrder("bullet1", "bullet2");
 		assertThat(catalog.getServices().get(0).getPlans().get(1).isBindable()).isTrue();
 		assertThat(catalog.getServices().get(0).getPlans().get(1).isFree()).isTrue();
 		assertThat(catalog.getServices().get(0).getPlans().get(1).getSchemas().getServiceInstance().getCreate().getParameters())

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.properties
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.properties
@@ -20,8 +20,14 @@ spring.cloud.openservicebroker.catalog.services[0].plans[0].description=Descript
 spring.cloud.openservicebroker.catalog.services[0].plans[1].id=plan-two-id
 spring.cloud.openservicebroker.catalog.services[0].plans[1].name=Plan Two
 spring.cloud.openservicebroker.catalog.services[0].plans[1].description=Description for Plan Two
-spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata[key1]=value1
-spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata[key2]=value2
+# extra metadata not specified in osb specs need to be specified as "extrametadata"
+spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.extra[key1]=value1
+spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.extra[key2]=value2
+spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.displayName=sample display name
+spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.bullets[0]=bullet1
+spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.bullets[1]=bullet2
+spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.costs[0].amount[usd]=649.0
+spring.cloud.openservicebroker.catalog.services[0].plans[1].metadata.costs[0].unit=MONTHLY
 spring.cloud.openservicebroker.catalog.services[0].plans[1].bindable=true
 spring.cloud.openservicebroker.catalog.services[0].plans[1].free=true
 spring.cloud.openservicebroker.catalog.services[0].plans[1].schemas.serviceinstance.create.parameters[$schema]=http://example.com/service/create/schema

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.yml
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.yml
@@ -31,8 +31,17 @@ spring:
             id: plan-two-id
             name: Plan Two
             metadata:
-              key1: value1
-              key2: value2
+              displayName: "sample display name"
+              bullets:
+                - "bullet1"
+                - "bullet2"
+              costs:
+                - amount:
+                    usd: 649.0
+                  unit: MONTHLY
+              extra: # extra metadata not specified in osb specs need to be specified here
+                key1: value1
+                key2: value2
             bindable: true
             free: true
             schemas:

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
@@ -241,6 +241,9 @@ public class Plan {
 		 * metadata conventions</a>
 		 */
 		public PlanBuilder metadata(Map<String, Object> metadata) {
+			if (metadata == null) {
+				return this;
+			}
 			if (this.metadata == null) {
 				this.metadata = new HashMap<>();
 			}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
@@ -21,7 +21,9 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.JsonUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,10 +62,27 @@ public class PlanTest {
 	@Test
 	@SuppressWarnings("serial")
 	public void planWithAllFieldsIsSerializedToJson() {
-		Map<String, Object> metadata = new HashMap<String, Object>() {{
-			put("field3", "value3");
-			put("field4", "value4");
-		}};
+		HashMap<String, Object> standardCost = new HashMap<String, Object>() {
+			{
+				put("unit", "MONTHLY");
+				put("amount", new HashMap<String, Object>() {
+					{
+						put("usd", 649.0d);
+					}
+				});
+			}
+		};
+		List<HashMap<String, Object>> costs = new ArrayList<>();
+		costs.add(standardCost);
+		Map<String, Object> metadata = new HashMap<String, Object>() {
+			{
+				put("field3", "value3");
+				put("field4", "value4");
+				put("bullets", new String[] { "bullet1", "bullet2" });
+				put("costs", costs);
+				put("displayName", "sample display name");
+			}
+		};
 
 		Plan plan = Plan.builder()
 				.id("plan-id-one")
@@ -82,12 +101,15 @@ public class PlanTest {
 		assertThat(plan.getDescription()).isEqualTo("Plan One");
 		assertThat(plan.isFree()).isEqualTo(false);
 		assertThat(plan.isBindable()).isEqualTo(true);
-		assertThat(plan.getMetadata()).hasSize(4);
+		assertThat(plan.getMetadata()).hasSize(7);
 		assertThat(plan.getMetadata()).contains(
 				entry("field1", "value1"),
 				entry("field2", "value2"),
 				entry("field3", "value3"),
-				entry("field4", "value4")
+				entry("field4", "value4"),
+				entry("displayName", "sample display name"),
+				entry("bullets", new String[]{"bullet1", "bullet2"}),
+				entry("costs", costs)
 		);
 		assertThat(plan.getSchemas()).isNotNull();
 
@@ -104,6 +126,12 @@ public class PlanTest {
 				entry("field3", "value3"),
 				entry("field4", "value4")
 		);
+		assertThat(json).hasPath("$.metadata.displayName").isEqualTo("sample display name");
+		assertThat(json).hasPath("$.metadata.costs");
+		assertThat(json).hasMapAtPath("$.metadata.costs[0]");
+		assertThat(json).hasMapAtPath("$.metadata.costs[0].amount").contains(entry("usd", 649.0d));
+		assertThat(json).hasPath("$.metadata.costs[0].unit").isEqualTo("MONTHLY");
+		assertThat(json).hasListAtPath("$.metadata.bullets").containsOnly("bullet1", "bullet2");
 		assertThat(json).hasPath("$.schemas");
 	}
 


### PR DESCRIPTION
Tests that reproduce #155

I'm happy to try to update this PR to provide a fix, but have the following related needs:
* That would however be easier if #154 and #140 could be reviewed and merged as the fix is likely to conflict with these branches
* I was considering adding a new web.Metadata configuration properties object similar to below. I need to research more to find a easy way to support both free form plan.metadata fields (e.g. "key1/value1" with typed POJO for Bullets and Costs arrays that need to be annotated with @NestedConfigurationProperty. As a 1st step, I was considering sacrifying support for custom free form metadata, in favor of the standard metadata fields `displayName`, `costs` and `bullets`. I'd appreciate feedback on this limitation.


```java
public class Metadata {

    @NestedConfigurationProperty
    private List<Cost> costs = new ArrayList<Cost>();
    
    private List<String> bullets = new ArrayList<>();

    public static class Cost {

        private Map<String, Double> amount = new HashMap<>();
        private String unit;

    }
}
```