### PR TITLE
Add support for custom base path of service broker controllers

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractBasePathIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractBasePathIntegrationTest.java
@@ -1,0 +1,108 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web;
+
+import static java.lang.String.format;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.servicebroker.JsonUtils;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceResponse;
+import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceResponse;
+import org.springframework.cloud.servicebroker.service.CatalogService;
+import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import reactor.core.publisher.Mono;
+import wiremock.com.google.common.base.Objects;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+		webEnvironment = WebEnvironment.MOCK,
+		classes = AbstractBasePathIntegrationTest.ServiceBrokerApplication.class
+)
+public abstract class AbstractBasePathIntegrationTest {
+	
+	protected abstract void assertFound(String baseUri, String expectedPlatform);
+	protected abstract void assertNotFound(String baseUri);
+
+	protected final String serviceCreationPayload() {
+		return JsonUtils.toJson(CreateServiceInstanceRequest.builder()
+				                                            .serviceDefinitionId("default-service")
+				                                            .planId("default-plan")
+				                                            .build()
+	    );
+	}
+
+
+
+	@SpringBootApplication
+	@Configuration
+	protected static class ServiceBrokerApplication {
+		
+		@Bean
+		public CatalogService catalogService() {
+			return new CatalogService() {
+				
+				@Override
+				public Mono<ServiceDefinition> getServiceDefinition(String serviceId) {
+					return this.getCatalog()
+							   .flatMapIterable(Catalog::getServiceDefinitions)
+							   .filter(service -> Objects.equal(serviceId, service.getId()))
+							   .next();
+				}
+				
+				@Override
+				public Mono<Catalog> getCatalog() {
+					return Mono.just(
+							Catalog.builder()
+								   .serviceDefinitions(
+										   ServiceDefinition.builder()
+										                    .id("default-service")
+										                    .plans(
+										                    		Plan.builder()
+										                    		    .id("default-plan")
+										                    		    .build()
+										                    )
+										                    .build()
+								   )
+							       .build()
+					);
+				}
+			};
+		}
+		
+		@Bean
+		public ServiceInstanceService serviceInstanceService() {
+			return new ServiceInstanceService() {
+				
+				@Override
+				public Mono<DeleteServiceInstanceResponse> deleteServiceInstance(DeleteServiceInstanceRequest request) {
+					return Mono.error(() -> new UnsupportedOperationException());
+				}
+				
+				@Override
+				public Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
+					return Mono.just(CreateServiceInstanceResponse.builder()
+					                                              .operation(format("platform: %s", request.getPlatformInstanceId()))
+					                                              .build()
+				    );
+				}
+			};
+		}
+		
+
+		public static void main(String[] args) {
+			SpringApplication.run(ServiceBrokerApplication.class, args);
+		}
+
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/AbstractBasePathWebApplicationIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/AbstractBasePathWebApplicationIntegrationTest.java
@@ -1,0 +1,53 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
+
+import static java.lang.String.format;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.cloud.servicebroker.JsonUtils;
+import org.springframework.cloud.servicebroker.autoconfigure.web.AbstractBasePathIntegrationTest;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
+
+
+@TestPropertySource(properties = "spring.main.web-application-type=reactive")
+@AutoConfigureWebTestClient
+public abstract class AbstractBasePathWebApplicationIntegrationTest extends AbstractBasePathIntegrationTest {
+	
+	@Autowired
+	protected WebTestClient client;
+	
+	@Override
+	protected void assertFound(String baseUri, String expectedPlatform) {
+		ResponseSpec exchange = createExchange(baseUri);
+		exchange
+		            .expectStatus().isCreated()
+		            .expectBody().jsonPath("operation")
+		                         .isEqualTo(format("platform: %s", expectedPlatform))
+		;
+	}
+	
+	@Override
+	protected void assertNotFound(String baseUri) {
+		ResponseSpec exchange = createExchange(baseUri);
+		exchange.expectStatus().isNotFound();
+	}
+
+
+	private ResponseSpec createExchange(String baseUri) {
+		String request = JsonUtils.toJson(CreateServiceInstanceRequest.builder()
+				                                                      .serviceDefinitionId("default-service")
+				                                                      .planId("default-plan")
+				                                                      .build()
+				         );
+		ResponseSpec exchange = client.put().uri(format("%s/v2/service_instances/default-service", baseUri))
+		            .accept(MediaType.APPLICATION_JSON)
+		            .contentType(MediaType.APPLICATION_JSON)
+		            .syncBody(request)
+		            .exchange();
+		return exchange;
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/BasePathDoubleIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/BasePathDoubleIntegrationTest.java
@@ -1,0 +1,33 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
+
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "spring.cloud.openservicebroker.base-path=/api/broker")
+public class BasePathDoubleIntegrationTest extends AbstractBasePathWebApplicationIntegrationTest {
+	
+	@Test
+	public void noPrefix() {
+		assertNotFound("");
+	}
+	
+	@Test
+	public void withSinglePrefix() {
+		assertNotFound("/123");
+	}
+	
+	@Test
+	public void withDoublePrefix() {
+		assertFound("/api/broker", "null");
+	}
+
+	@Test
+	public void withTriplePrefix() {
+		assertFound("/api/broker/123", "123");
+	}
+
+	@Test
+	public void withQuadruplePrefix() {
+		assertNotFound("/api/broker/123/456");
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/BasePathEmptyIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/BasePathEmptyIntegrationTest.java
@@ -1,0 +1,31 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
+
+import org.junit.Test;
+
+
+public class BasePathEmptyIntegrationTest extends AbstractBasePathWebApplicationIntegrationTest {
+	
+	@Test
+	public void noPrefix() {
+		assertFound("", "null");
+	}
+	
+	@Test
+	public void withSinglePrefix() {
+		assertFound("/123", "123");
+	}
+	
+	@Test
+	public void withDoublePrefix() {
+		assertNotFound("/api/broker");
+	}
+	@Test
+	public void withTriplePrefix() {
+		assertNotFound("/api/broker/123");
+	}
+
+	@Test
+	public void withQuadruplePrefix() {
+		assertNotFound("/api/broker/123/456");
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/BasePathSimpleIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/BasePathSimpleIntegrationTest.java
@@ -1,0 +1,33 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
+
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "spring.cloud.openservicebroker.base-path=/broker")
+public class BasePathSimpleIntegrationTest extends AbstractBasePathWebApplicationIntegrationTest {
+	
+	@Test
+	public void noPrefix() {
+		assertNotFound("");
+	}
+	
+	@Test
+	public void withSinglePrefix() {
+		assertNotFound("/123");
+	}
+	
+	@Test
+	public void withDoublePrefix() {
+		assertNotFound("/api/broker");
+	}
+
+	@Test
+	public void withTriplePrefix() {
+		assertNotFound("/api/broker/123");
+	}
+
+	@Test
+	public void withQuadruplePrefix() {
+		assertNotFound("/api/broker/123/456");
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/AbstractBasePathWebApplicationIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/AbstractBasePathWebApplicationIntegrationTest.java
@@ -1,0 +1,71 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
+
+import static java.lang.String.format;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.cloud.servicebroker.autoconfigure.web.AbstractBasePathIntegrationTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+@TestPropertySource(properties = "spring.main.web-application-type=servlet")
+@AutoConfigureMockMvc
+public abstract class AbstractBasePathWebApplicationIntegrationTest extends AbstractBasePathIntegrationTest {
+	
+	@Autowired
+    private MockMvc mvc;
+	
+	protected void assertFound(String baseUri, String expectedPlatform) {
+		ResultActions response = makeRequest(baseUri, true);
+		try {
+			response.andExpect(status().isCreated())
+			        .andExpect(jsonPath("operation").value(format("platform: %s", expectedPlatform)))
+			;
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	protected void assertNotFound(String baseUri) {
+		ResultActions response = makeRequest(baseUri, false);
+		try {
+			response.andExpect(status().isNotFound());
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+
+	private ResultActions makeRequest(String baseUri, boolean async) {
+		try {
+			ResultActions actions = mvc.perform(put(format("%s/v2/service_instances/default-service", baseUri))
+					                               .accept(MediaType.APPLICATION_JSON)
+					                               .contentType(MediaType.APPLICATION_JSON)
+					                               .content(serviceCreationPayload())
+			                           );
+			if (!async) {
+				return actions;
+			}
+			MvcResult result = actions.andExpect(request().asyncStarted())
+                                      .andReturn();
+			return mvc.perform(asyncDispatch(result));
+		} catch (RuntimeException e) {
+				throw e;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/BasePathDoubleIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/BasePathDoubleIntegrationTest.java
@@ -1,0 +1,33 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
+
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "spring.cloud.openservicebroker.base-path=/api/broker")
+public class BasePathDoubleIntegrationTest extends AbstractBasePathWebApplicationIntegrationTest {
+	
+	@Test
+	public void noPrefix() {
+		assertNotFound("");
+	}
+	
+	@Test
+	public void withSinglePrefix() {
+		assertNotFound("/123");
+	}
+	
+	@Test
+	public void withDoublePrefix() {
+		assertFound("/api/broker", "null");
+	}
+
+	@Test
+	public void withTriplePrefix() {
+		assertFound("/api/broker/123", "123");
+	}
+
+	@Test
+	public void withQuadruplePrefix() {
+		assertNotFound("/api/broker/123/456");
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/BasePathEmptyIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/BasePathEmptyIntegrationTest.java
@@ -1,0 +1,31 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
+
+import org.junit.Test;
+
+
+public class BasePathEmptyIntegrationTest extends AbstractBasePathWebApplicationIntegrationTest {
+	
+	@Test
+	public void noPrefix() {
+		assertFound("", "null");
+	}
+	
+	@Test
+	public void withSinglePrefix() {
+		assertFound("/123", "123");
+	}
+	
+	@Test
+	public void withDoublePrefix() {
+		assertNotFound("/api/broker");
+	}
+	@Test
+	public void withTriplePrefix() {
+		assertNotFound("/api/broker/123");
+	}
+
+	@Test
+	public void withQuadruplePrefix() {
+		assertNotFound("/api/broker/123/456");
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/BasePathSimpleIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/BasePathSimpleIntegrationTest.java
@@ -1,0 +1,33 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
+
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "spring.cloud.openservicebroker.base-path=/broker")
+public class BasePathSimpleIntegrationTest extends AbstractBasePathWebApplicationIntegrationTest {
+	
+	@Test
+	public void noPrefix() {
+		assertNotFound("");
+	}
+	
+	@Test
+	public void withSinglePrefix() {
+		assertNotFound("/123");
+	}
+	
+	@Test
+	public void withDoublePrefix() {
+		assertNotFound("/api/broker");
+	}
+
+	@Test
+	public void withTriplePrefix() {
+		assertNotFound("/api/broker/123");
+	}
+
+	@Test
+	public void withQuadruplePrefix() {
+		assertNotFound("/api/broker/123/456");
+	}
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/ServiceBrokerRestController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/ServiceBrokerRestController.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.servicebroker.annotation;
 
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.lang.annotation.Documented;
@@ -29,6 +30,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @RestController
+@RequestMapping("${spring.cloud.openservicebroker.base-path:}")
 public @interface ServiceBrokerRestController {
 	@AliasFor(annotation = RestController.class)
 	String value() default "";


### PR DESCRIPTION
Let's define a path prefix to expose service broker controllers through
"spring.cloud.openservicebroker.base-path" property.
This way Spring Boot application can be used to expose additionnal
endpoint without conflicts.