### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'base'
 buildscript {
     repositories {
         mavenCentral()
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
@@ -49,8 +49,8 @@ ext {
     jsonPathVersion = '0.9.1'
 
     javadocLinks = [
-            'http://docs.oracle.com/javase/8/docs/api/',
-            'http://docs.spring.io/spring/docs/current/javadoc-api/',
+            'https://docs.oracle.com/javase/8/docs/api/',
+            'https://docs.spring.io/spring/docs/current/javadoc-api/',
     ] as String[]
 }
 

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -22,7 +22,7 @@ def customizePom(pom, gradleProject) {
 		generatedPom.project {
 			name = gradleProject.description
 			description = gradleProject.description
-			url = 'http://projects.spring.io/spring-cloud'
+			url = 'https://projects.spring.io/spring-cloud'
 			organization {
 				name = 'Spring IO'
 				url = 'https://spring.io'
@@ -30,7 +30,7 @@ def customizePom(pom, gradleProject) {
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javase/8/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/ ([https](https://docs.oracle.com/javase/8/docs/api/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://projects.spring.io/spring-cloud with 1 occurrences migrated to:  
  https://projects.spring.io/spring-cloud ([https](https://projects.spring.io/spring-cloud) result 301).
* http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).