### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/config/pmdTestRuleSet.xml
+++ b/config/pmdTestRuleSet.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~       https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Catalog.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Catalog.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/DashboardClient.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/DashboardClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/MethodSchema.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/MethodSchema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Schemas.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Schemas.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBindingSchema.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBindingSchema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerProperties.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceDefinition.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceSchema.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceSchema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/package-info.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilter.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/package-info.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionInterceptor.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcConfigurerAdapter.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/package-info.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/CatalogReactiveBase.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/CatalogReactiveBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/CatalogServletBase.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/CatalogServletBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/InstanceReactiveBase.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/InstanceReactiveBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/InstanceServletBase.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/contract/InstanceServletBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceInstanceBindingControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceInstanceControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesValidationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesValidationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceBindingIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceInstanceBindingIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestCatalogService.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestCatalogService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceBindingService.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceBindingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceService.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/fixture/ServiceFixture.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/fixture/ServiceFixture.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilterIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilterIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilterTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFluxAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/CatalogControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/CatalogControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/NonBindableServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/NonBindableServiceInstanceBindingControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionInterceptorIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionInterceptorIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionInterceptorTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ApiVersionWebMvcAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/CatalogControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/CatalogControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/NonBindableServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/NonBindableServiceInstanceBindingControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/apiversion.properties
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/apiversion.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/Instance/reactive/createServiceInstance.groovy
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/Instance/reactive/createServiceInstance.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/Instance/servlet/createServiceInstance.groovy
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/Instance/servlet/createServiceInstance.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/reactive/retrieveCatalog.groovy
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/reactive/retrieveCatalog.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/reactive/retrieveInstanceCatalog.groovy
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/reactive/retrieveInstanceCatalog.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/servlet/retrieveCatalog.groovy
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/servlet/retrieveCatalog.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/servlet/retrieveInstanceCatalog.groovy
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/contracts/catalog/servlet/retrieveInstanceCatalog.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/ServiceBrokerRestController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/ServiceBrokerRestController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/annotation/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerApiVersionErrorMessage.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerApiVersionErrorMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerApiVersionException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerApiVersionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerAsyncRequiredException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerAsyncRequiredException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerBindingRequiresAppException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerBindingRequiresAppException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerConcurrencyException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerConcurrencyException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerInvalidOriginatingIdentityException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerInvalidOriginatingIdentityException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerInvalidParametersException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerInvalidParametersException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerOperationInProgressException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerOperationInProgressException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerUnavailableException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerUnavailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceDefinitionDoesNotExistException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceDefinitionDoesNotExistException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceBindingDoesNotExistException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceBindingDoesNotExistException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceBindingExistsException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceBindingExistsException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceDoesNotExistException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceDoesNotExistException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceExistsException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceExistsException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceUpdateNotSupportedException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceUpdateNotSupportedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/BrokerApiVersion.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/BrokerApiVersion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/CloudFoundryContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/KubernetesContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/PlatformContext.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/PlatformContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/BindResource.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/BindResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceAppBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceAppBindingResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceRouteBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceRouteBindingResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceAppBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceAppBindingResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceRouteBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceRouteBindingResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/SharedVolumeDevice.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/SharedVolumeDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/VolumeDevice.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/VolumeDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/VolumeMount.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/VolumeMount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Catalog.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Catalog.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/DashboardClient.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/DashboardClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/MethodSchema.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/MethodSchema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Schemas.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Schemas.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceBindingSchema.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceBindingSchema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinition.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinitionRequires.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinitionRequires.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceInstanceSchema.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceInstanceSchema.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/ErrorMessage.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/ErrorMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/OperationState.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/OperationState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/util/ParameterBeanMapper.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/util/ParameterBeanMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/util/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/util/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/BeanCatalogService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/BeanCatalogService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/CatalogService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/CatalogService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/NonBindableServiceInstanceBindingService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/NonBindableServiceInstanceBindingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceEventService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceEventService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/AsyncOperationServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/AsyncOperationServiceInstanceEventFlowRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceBindingEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceBindingEventFlowRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceEventFlowRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceBindingEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceBindingEventFlowRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceEventFlowRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistries.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistries.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/UpdateServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/UpdateServiceInstanceEventFlowRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceCompletionFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceCompletionFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceErrorFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceErrorFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceInitializationFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceInitializationFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceBindingCompletionFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceBindingCompletionFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceBindingErrorFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceBindingErrorFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceBindingInitializationFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceBindingInitializationFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceCompletionFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceCompletionFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceErrorFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceErrorFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceInitializationFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/CreateServiceInstanceInitializationFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceBindingCompletionFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceBindingCompletionFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceBindingErrorFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceBindingErrorFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceBindingInitializationFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceBindingInitializationFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceCompletionFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceCompletionFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceErrorFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceErrorFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceInitializationFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/DeleteServiceInstanceInitializationFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/UpdateServiceInstanceCompletionFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/UpdateServiceInstanceCompletionFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/UpdateServiceInstanceErrorFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/UpdateServiceInstanceErrorFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/UpdateServiceInstanceInitializationFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/UpdateServiceInstanceInitializationFlow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/package-info.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/JsonPathAssert.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/JsonPathAssert.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/JsonUtils.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/JsonUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/CatalogControllerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/CatalogControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ControllerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ControllerRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerApiVersionErrorMessageTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerApiVersionErrorMessageTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/CloudFoundryContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/CloudFoundryContextTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ContextTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/KubernetesContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/KubernetesContextTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/PlatformContextTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/PlatformContextTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/BindResourceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/BindResourceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceAppBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceAppBindingResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceRouteBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceRouteBindingResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceAppBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceAppBindingResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceRouteBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceRouteBindingResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/SharedVolumeDeviceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/SharedVolumeDeviceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/VolumeMountTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/VolumeMountTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/CatalogTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/CatalogTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/DashboardClientTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/DashboardClientTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/SchemasTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/SchemasTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinitionTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinitionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/error/ErrorMessageTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/error/ErrorMessageTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/util/ParameterBeanMapperTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/util/ParameterBeanMapperTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/BeanCatalogServiceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/BeanCatalogServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/NonBindableServiceInstanceBindingServiceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/NonBindableServiceInstanceBindingServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventServiceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceEventServiceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceEventServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 227 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).