### PR TITLE
URL Cleanup

### DIFF
--- a/config/pmdRuleSet.xml
+++ b/config/pmdRuleSet.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="Custom ruleset"
-		 xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+		 xmlns="https://pmd.sourceforge.io/ruleset/2.0.0"
+		 xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://pmd.sourceforge.io/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
 	<rule ref="rulesets/java/basic.xml"/>
 	<rule ref="rulesets/java/braces.xml">

--- a/config/pmdTestRuleSet.xml
+++ b/config/pmdTestRuleSet.xml
@@ -16,9 +16,9 @@
   -->
 
 <ruleset name="Custom ruleset"
-		 xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+		 xmlns="https://pmd.sourceforge.io/ruleset/2.0.0"
+		 xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://pmd.sourceforge.io/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
 	<rule ref="rulesets/java/basic.xml"/>
 	<rule ref="rulesets/java/braces.xml">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://pmd.sourceforge.net/ruleset/2.0.0 (301) with 4 occurrences migrated to:  
  https://pmd.sourceforge.io/ruleset/2.0.0 ([https](https://pmd.sourceforge.net/ruleset/2.0.0) result AnnotatedConnectException).
* [ ] http://pmd.sourceforge.net/ruleset_2_0_0.xsd (301) with 2 occurrences migrated to:  
  https://pmd.sourceforge.io/ruleset_2_0_0.xsd ([https](https://pmd.sourceforge.net/ruleset_2_0_0.xsd) result AnnotatedConnectException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.w3.org/2001/XMLSchema-instance with 2 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).