### PR TITLE
Support auto-configuration of event flows via bean definitions

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/EventFlowsAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/EventFlowsAutoConfiguration.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web;
+
+import java.util.List;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.servicebroker.autoconfigure.web.exception.CatalogDefinitionDoesNotExistException;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.service.BeanCatalogService;
+import org.springframework.cloud.servicebroker.service.CatalogService;
+import org.springframework.cloud.servicebroker.service.NonBindableServiceInstanceBindingService;
+import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
+import org.springframework.cloud.servicebroker.service.events.AsyncOperationServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.CreateServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.CreateServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.DeleteServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.DeleteServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
+import org.springframework.cloud.servicebroker.service.events.UpdateServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceBindingCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceBindingErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceBindingInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.UpdateServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.UpdateServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.UpdateServiceInstanceInitializationFlow;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for the event flow implementation beans.
+ *
+ * @author Roy Clarkson
+ */
+@Configuration
+public class EventFlowsAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(CreateServiceInstanceEventFlowRegistry.class)
+	public CreateServiceInstanceEventFlowRegistry createInstanceRegistry(
+			@Autowired(required = false) List<CreateServiceInstanceInitializationFlow> initializationFlows,
+			@Autowired(required = false) List<CreateServiceInstanceCompletionFlow> completionFlows,
+			@Autowired(required = false) List<CreateServiceInstanceErrorFlow> errorFlows) {
+		return new CreateServiceInstanceEventFlowRegistry(initializationFlows, completionFlows, errorFlows);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(DeleteServiceInstanceEventFlowRegistry.class)
+	public DeleteServiceInstanceEventFlowRegistry deleteInstanceRegistry(
+			@Autowired(required = false) List<DeleteServiceInstanceInitializationFlow> initializationFlows,
+			@Autowired(required = false) List<DeleteServiceInstanceCompletionFlow> completionFlows,
+			@Autowired(required = false) List<DeleteServiceInstanceErrorFlow> errorFlows) {
+		return new DeleteServiceInstanceEventFlowRegistry(initializationFlows, completionFlows, errorFlows);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(UpdateServiceInstanceEventFlowRegistry.class)
+	public UpdateServiceInstanceEventFlowRegistry updateInstanceRegistry(
+			@Autowired(required = false) List<UpdateServiceInstanceInitializationFlow> initializationFlows,
+			@Autowired(required = false) List<UpdateServiceInstanceCompletionFlow> completionFlows,
+			@Autowired(required = false) List<UpdateServiceInstanceErrorFlow> errorFlows) {
+		return new UpdateServiceInstanceEventFlowRegistry(initializationFlows, completionFlows, errorFlows);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(AsyncOperationServiceInstanceEventFlowRegistry.class)
+	public AsyncOperationServiceInstanceEventFlowRegistry asyncOperationRegistry(
+			@Autowired(required = false) List<AsyncOperationServiceInstanceInitializationFlow> initializationFlows,
+			@Autowired(required = false) List<AsyncOperationServiceInstanceCompletionFlow> completionFlows,
+			@Autowired(required = false) List<AsyncOperationServiceInstanceErrorFlow> errorFlows) {
+		return new AsyncOperationServiceInstanceEventFlowRegistry(initializationFlows, completionFlows, errorFlows);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(CreateServiceInstanceBindingEventFlowRegistry.class)
+	public CreateServiceInstanceBindingEventFlowRegistry createInstanceBindingRegistry(
+			@Autowired(required = false) List<CreateServiceInstanceBindingInitializationFlow> initializationFlows,
+			@Autowired(required = false) List<CreateServiceInstanceBindingCompletionFlow> completionFlows,
+			@Autowired(required = false) List<CreateServiceInstanceBindingErrorFlow> errorFlows) {
+		return new CreateServiceInstanceBindingEventFlowRegistry(initializationFlows, completionFlows, errorFlows);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(DeleteServiceInstanceBindingEventFlowRegistry.class)
+	public DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry(
+			@Autowired(required = false) List<DeleteServiceInstanceBindingInitializationFlow> initializationFlows,
+			@Autowired(required = false) List<DeleteServiceInstanceBindingCompletionFlow> completionFlows,
+			@Autowired(required = false) List<DeleteServiceInstanceBindingErrorFlow> errorFlows) {
+		return new DeleteServiceInstanceBindingEventFlowRegistry(initializationFlows, completionFlows, errorFlows);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(EventFlowRegistries.class)
+	public EventFlowRegistries eventFlowRegistries(
+			CreateServiceInstanceEventFlowRegistry createInstanceRegistry,
+			UpdateServiceInstanceEventFlowRegistry updateInstanceRegistry,
+			DeleteServiceInstanceEventFlowRegistry deleteInstanceRegistry,
+			AsyncOperationServiceInstanceEventFlowRegistry asyncOperationRegistry,
+			CreateServiceInstanceBindingEventFlowRegistry createInstanceBindingRegistry,
+			DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry) {
+		return new EventFlowRegistries(createInstanceRegistry, updateInstanceRegistry, deleteInstanceRegistry,
+				asyncOperationRegistry, createInstanceBindingRegistry, deleteInstanceBindingRegistry);
+	}
+
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.cloud.servicebroker.service.BeanCatalogService;
 import org.springframework.cloud.servicebroker.service.CatalogService;
 import org.springframework.cloud.servicebroker.service.NonBindableServiceInstanceBindingService;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
-import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -80,11 +79,6 @@ public class ServiceBrokerAutoConfiguration {
 	@ConditionalOnMissingBean(ServiceInstanceBindingService.class)
 	public ServiceInstanceBindingService nonBindableServiceInstanceBindingService() {
 		return new NonBindableServiceInstanceBindingService();
-	}
-
-	@Bean
-	public EventFlowRegistries eventFlowRegistries() {
-		return new EventFlowRegistries();
 	}
 
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
+import org.springframework.cloud.servicebroker.autoconfigure.web.EventFlowsAutoConfiguration;
 import org.springframework.cloud.servicebroker.autoconfigure.web.ServiceBrokerAutoConfiguration;
 import org.springframework.cloud.servicebroker.autoconfigure.web.exception.ServiceInstanceServiceBeanDoesNotExistException;
 import org.springframework.cloud.servicebroker.controller.CatalogController;
@@ -44,8 +44,8 @@ import org.springframework.context.annotation.Configuration;
  * @author Roy Clarkson
  */
 @Configuration
-@AutoConfigureAfter({ WebFluxAutoConfiguration.class,
-		ServiceBrokerAutoConfiguration.class })
+@AutoConfigureAfter({WebFluxAutoConfiguration.class,
+		ServiceBrokerAutoConfiguration.class, EventFlowsAutoConfiguration.class})
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 public class ServiceBrokerWebFluxAutoConfiguration {
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.cloud.servicebroker.autoconfigure.web.EventFlowsAutoConfiguration;
 import org.springframework.cloud.servicebroker.autoconfigure.web.ServiceBrokerAutoConfiguration;
 import org.springframework.cloud.servicebroker.autoconfigure.web.exception.ServiceInstanceServiceBeanDoesNotExistException;
 import org.springframework.cloud.servicebroker.controller.CatalogController;
@@ -45,8 +45,8 @@ import org.springframework.context.annotation.Configuration;
  * @author Roy Clarkson
  */
 @Configuration
-@AutoConfigureAfter({ WebMvcAutoConfiguration.class,
-		ServiceBrokerAutoConfiguration.class })
+@AutoConfigureAfter({WebMvcAutoConfiguration.class,
+		ServiceBrokerAutoConfiguration.class, EventFlowsAutoConfiguration.class})
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class ServiceBrokerWebMvcAutoConfiguration {
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceBrokerWebAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceBrokerWebAutoConfigurationTest.java
@@ -84,6 +84,7 @@ public abstract class AbstractServiceBrokerWebAutoConfigurationTest {
 			return new TestServiceInstanceBindingService();
 		}
 
+		@SuppressWarnings("deprecation")
 		@Bean
 		public EventFlowRegistries eventFlowRegistries() {
 			return new EventFlowRegistries();
@@ -103,6 +104,7 @@ public abstract class AbstractServiceBrokerWebAutoConfigurationTest {
 			return new TestServiceInstanceBindingService();
 		}
 
+		@SuppressWarnings("deprecation")
 		@Bean
 		public EventFlowRegistries eventFlowRegistries() {
 			return new EventFlowRegistries();

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/EventFlowsAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/EventFlowsAutoConfigurationTest.java
@@ -1,0 +1,482 @@
+package org.springframework.cloud.servicebroker.autoconfigure.web;
+
+import java.util.List;
+
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingRequest;
+import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingResponse;
+import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingRequest;
+import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingResponse;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceResponse;
+import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceResponse;
+import org.springframework.cloud.servicebroker.model.instance.GetLastServiceOperationRequest;
+import org.springframework.cloud.servicebroker.model.instance.GetLastServiceOperationResponse;
+import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceResponse;
+import org.springframework.cloud.servicebroker.service.events.AsyncOperationServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.CreateServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.CreateServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.DeleteServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.DeleteServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
+import org.springframework.cloud.servicebroker.service.events.EventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.UpdateServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceBindingCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceBindingErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceBindingInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.DeleteServiceInstanceInitializationFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.UpdateServiceInstanceCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.UpdateServiceInstanceErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.UpdateServiceInstanceInitializationFlow;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EventFlowsAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(EventFlowsAutoConfiguration.class));
+
+	@Test
+	public void servicesAreCreatedWithMinimalConfiguration() {
+		this.contextRunner.run(this::assertBeans);
+	}
+
+	@Test
+	public void servicesAreCreatedWithAlternateFlowBeansConfiguration() {
+		this.contextRunner
+				.withUserConfiguration(AlternateEventFlowRegistryBeansConfiguration.class)
+				.run(this::assertBeans);
+	}
+
+	@Test
+	public void createInstanceEventFlowBeansAreConfigured() {
+		this.contextRunner
+				.withUserConfiguration(CreateInstanceEventFlowBeansConfiguration.class)
+				.run(context -> {
+					assertBeans(context);
+					CreateServiceInstanceEventFlowRegistry registry =
+							context.getBean(CreateServiceInstanceEventFlowRegistry.class);
+					assertEventFlowBeans(registry, 2, 1, 1);
+				});
+	}
+
+	@Test
+	public void updateInstanceEventFlowBeansAreConfigured() {
+		this.contextRunner
+				.withUserConfiguration(UpdateInstanceEventFlowBeansConfiguration.class)
+				.run(context -> {
+					assertBeans(context);
+					UpdateServiceInstanceEventFlowRegistry registry =
+							context.getBean(UpdateServiceInstanceEventFlowRegistry.class);
+					assertEventFlowBeans(registry, 1, 1, 1);
+				});
+	}
+
+	@Test
+	public void deleteInstanceEventFlowBeansAreConfigured() {
+		this.contextRunner
+				.withUserConfiguration(DeleteInstanceEventFlowBeansConfiguration.class)
+				.run(context -> {
+					assertBeans(context);
+					DeleteServiceInstanceEventFlowRegistry registry =
+							context.getBean(DeleteServiceInstanceEventFlowRegistry.class);
+					assertEventFlowBeans(registry, 1, 1, 2);
+				});
+	}
+
+	@Test
+	public void asyncOperationEventFlowBeansAreConfigured() {
+		this.contextRunner
+				.withUserConfiguration(AsyncOperationServiceInstanceEventFlowBeansConfiguration.class)
+				.run(context -> {
+					assertBeans(context);
+					AsyncOperationServiceInstanceEventFlowRegistry registry =
+							context.getBean(AsyncOperationServiceInstanceEventFlowRegistry.class);
+					assertEventFlowBeans(registry, 1, 2, 1);
+				});
+	}
+
+	@Test
+	public void createInstanceBindingEventFlowBeansAreConfigured() {
+		this.contextRunner
+				.withUserConfiguration(CreateInstanceBindingEventFlowBeansConfiguration.class)
+				.run(context -> {
+					assertBeans(context);
+					CreateServiceInstanceBindingEventFlowRegistry registry =
+							context.getBean(CreateServiceInstanceBindingEventFlowRegistry.class);
+					assertEventFlowBeans(registry, 1, 1, 1);
+				});
+	}
+
+	@Test
+	public void deleteInstanceBindingEventFlowBeansAreConfigured() {
+		this.contextRunner
+				.withUserConfiguration(DeleteInstanceBindingEventFlowBeansConfiguration.class)
+				.run(context -> {
+					assertBeans(context);
+					DeleteServiceInstanceBindingEventFlowRegistry registry =
+							context.getBean(DeleteServiceInstanceBindingEventFlowRegistry.class);
+					assertEventFlowBeans(registry, 1, 1, 1);
+				});
+	}
+
+	private void assertBeans(AssertableApplicationContext context) {
+		assertThat(context)
+				.getBean(CreateServiceInstanceEventFlowRegistry.class)
+				.isNotNull();
+
+		assertThat(context)
+				.getBean(UpdateServiceInstanceEventFlowRegistry.class)
+				.isNotNull();
+
+		assertThat(context)
+				.getBean(DeleteServiceInstanceEventFlowRegistry.class)
+				.isNotNull();
+
+		assertThat(context)
+				.getBean(AsyncOperationServiceInstanceEventFlowRegistry.class)
+				.isNotNull();
+
+		assertThat(context)
+				.getBean(CreateServiceInstanceBindingEventFlowRegistry.class)
+				.isNotNull();
+
+		assertThat(context)
+				.getBean(DeleteServiceInstanceBindingEventFlowRegistry.class)
+				.isNotNull();
+
+		assertThat(context)
+				.getBean(EventFlowRegistries.class)
+				.isNotNull();
+
+		EventFlowRegistries eventFlowRegistries = context.getBean(EventFlowRegistries.class);
+		assertThat(eventFlowRegistries.getCreateInstanceRegistry())
+				.isEqualTo(context.getBean(CreateServiceInstanceEventFlowRegistry.class));
+
+		assertThat(eventFlowRegistries.getUpdateInstanceRegistry())
+				.isEqualTo(context.getBean(UpdateServiceInstanceEventFlowRegistry.class));
+
+		assertThat(eventFlowRegistries.getDeleteInstanceRegistry())
+				.isEqualTo(context.getBean(DeleteServiceInstanceEventFlowRegistry.class));
+
+		assertThat(eventFlowRegistries.getAsyncOperationRegistry())
+				.isEqualTo(context.getBean(AsyncOperationServiceInstanceEventFlowRegistry.class));
+
+		assertThat(eventFlowRegistries.getCreateInstanceBindingRegistry())
+				.isEqualTo(context.getBean(CreateServiceInstanceBindingEventFlowRegistry.class));
+
+		assertThat(eventFlowRegistries.getDeleteInstanceBindingRegistry())
+				.isEqualTo(context.getBean(DeleteServiceInstanceBindingEventFlowRegistry.class));
+	}
+
+	private void assertEventFlowBeans(EventFlowRegistry<?, ?, ?, ?, ?> registry, int initializationFlowCount,
+									  int completionFlowCount, int errorFlowCount) {
+		List<?> initializationFlows = (List<?>) ReflectionTestUtils
+				.getField(registry, "initializationFlows");
+		assertThat(initializationFlows.size()).isEqualTo(initializationFlowCount);
+
+		List<?> completionFlows = (List<?>) ReflectionTestUtils.getField(registry, "completionFlows");
+		assertThat(completionFlows.size()).isEqualTo(completionFlowCount);
+
+		List<?> errorFlows = (List<?>) ReflectionTestUtils.getField(registry, "errorFlows");
+		assertThat(errorFlows.size()).isEqualTo(errorFlowCount);
+	}
+
+	@TestConfiguration
+	public static class AlternateEventFlowRegistryBeansConfiguration {
+
+		@SuppressWarnings("deprecation")
+		@Bean
+		public CreateServiceInstanceEventFlowRegistry createInstanceRegistry() {
+			return new CreateServiceInstanceEventFlowRegistry();
+		}
+
+		@SuppressWarnings("deprecation")
+		@Bean
+		public UpdateServiceInstanceEventFlowRegistry updateInstanceRegistry() {
+			return new UpdateServiceInstanceEventFlowRegistry();
+		}
+
+		@SuppressWarnings("deprecation")
+		@Bean
+		public DeleteServiceInstanceEventFlowRegistry deleteInstanceRegistry() {
+			return new DeleteServiceInstanceEventFlowRegistry();
+		}
+
+		@SuppressWarnings("deprecation")
+		@Bean
+		public CreateServiceInstanceBindingEventFlowRegistry createInstanceBindingRegistry() {
+			return new CreateServiceInstanceBindingEventFlowRegistry();
+		}
+
+		@SuppressWarnings("deprecation")
+		@Bean
+		public DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry() {
+			return new DeleteServiceInstanceBindingEventFlowRegistry();
+		}
+
+	}
+
+	@TestConfiguration
+	public static class CreateInstanceEventFlowBeansConfiguration {
+
+		@Bean
+		public CreateServiceInstanceInitializationFlow createInitFlow1() {
+			return new CreateServiceInstanceInitializationFlow() {
+				@Override
+				public Mono<Void> initialize(CreateServiceInstanceRequest request) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public CreateServiceInstanceInitializationFlow createInitFlow2() {
+			return new CreateServiceInstanceInitializationFlow() {
+				@Override
+				public Mono<Void> initialize(CreateServiceInstanceRequest request) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public CreateServiceInstanceCompletionFlow createCompleteFlow() {
+			return new CreateServiceInstanceCompletionFlow() {
+				@Override
+				public Mono<Void> complete(CreateServiceInstanceRequest request,
+										   CreateServiceInstanceResponse response) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public CreateServiceInstanceErrorFlow createErrorFlow() {
+			return new CreateServiceInstanceErrorFlow() {
+				@Override
+				public Mono<Void> error(CreateServiceInstanceRequest request, Throwable t) {
+					return Mono.empty();
+				}
+			};
+		}
+	}
+
+	@TestConfiguration
+	public static class UpdateInstanceEventFlowBeansConfiguration {
+
+		@Bean
+		public UpdateServiceInstanceInitializationFlow updateInitFlow() {
+			return new UpdateServiceInstanceInitializationFlow() {
+				@Override
+				public Mono<Void> initialize(UpdateServiceInstanceRequest request) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public UpdateServiceInstanceCompletionFlow updateCompleteFlow() {
+			return new UpdateServiceInstanceCompletionFlow() {
+				@Override
+				public Mono<Void> complete(UpdateServiceInstanceRequest request,
+										   UpdateServiceInstanceResponse response) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public UpdateServiceInstanceErrorFlow updateErrorFlow() {
+			return new UpdateServiceInstanceErrorFlow() {
+				@Override
+				public Mono<Void> error(UpdateServiceInstanceRequest request, Throwable t) {
+					return Mono.empty();
+				}
+			};
+		}
+	}
+
+	@TestConfiguration
+	public static class DeleteInstanceEventFlowBeansConfiguration {
+
+		@Bean
+		public DeleteServiceInstanceInitializationFlow deleteInitFlow() {
+			return new DeleteServiceInstanceInitializationFlow() {
+				@Override
+				public Mono<Void> initialize(DeleteServiceInstanceRequest request) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public DeleteServiceInstanceCompletionFlow deleteCompleteFlow() {
+			return new DeleteServiceInstanceCompletionFlow() {
+				@Override
+				public Mono<Void> complete(DeleteServiceInstanceRequest request,
+										   DeleteServiceInstanceResponse response) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public DeleteServiceInstanceErrorFlow deleteErrorFlow1() {
+			return new DeleteServiceInstanceErrorFlow() {
+				@Override
+				public Mono<Void> error(DeleteServiceInstanceRequest request, Throwable t) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public DeleteServiceInstanceErrorFlow deleteErrorFlow2() {
+			return new DeleteServiceInstanceErrorFlow() {
+				@Override
+				public Mono<Void> error(DeleteServiceInstanceRequest request, Throwable t) {
+					return Mono.empty();
+				}
+			};
+		}
+	}
+
+	@TestConfiguration
+	public static class AsyncOperationServiceInstanceEventFlowBeansConfiguration {
+
+		@Bean
+		public AsyncOperationServiceInstanceInitializationFlow getLastOperationInitFlow() {
+			return new AsyncOperationServiceInstanceInitializationFlow() {
+				@Override
+				public Mono<Void> initialize(GetLastServiceOperationRequest request) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public AsyncOperationServiceInstanceCompletionFlow getLastOperationCompleteFlow1() {
+			return new AsyncOperationServiceInstanceCompletionFlow() {
+				@Override
+				public Mono<Void> complete(GetLastServiceOperationRequest request,
+										   GetLastServiceOperationResponse response) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public AsyncOperationServiceInstanceCompletionFlow getLastOperationCompleteFlow2() {
+			return new AsyncOperationServiceInstanceCompletionFlow() {
+				@Override
+				public Mono<Void> complete(GetLastServiceOperationRequest request,
+										   GetLastServiceOperationResponse response) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public AsyncOperationServiceInstanceErrorFlow getLastOperationErrorFlow() {
+			return new AsyncOperationServiceInstanceErrorFlow() {
+				@Override
+				public Mono<Void> error(GetLastServiceOperationRequest request, Throwable t) {
+					return Mono.empty();
+				}
+			};
+		}
+	}
+
+	@TestConfiguration
+	public static class CreateInstanceBindingEventFlowBeansConfiguration {
+
+		@Bean
+		public CreateServiceInstanceBindingInitializationFlow createInitFlow() {
+			return new CreateServiceInstanceBindingInitializationFlow() {
+				@Override
+				public Mono<Void> initialize(CreateServiceInstanceBindingRequest request) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public CreateServiceInstanceBindingCompletionFlow createCompleteFlow() {
+			return new CreateServiceInstanceBindingCompletionFlow() {
+				@Override
+				public Mono<Void> complete(CreateServiceInstanceBindingRequest request,
+										   CreateServiceInstanceBindingResponse response) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public CreateServiceInstanceBindingErrorFlow createErrorFlow() {
+			return new CreateServiceInstanceBindingErrorFlow() {
+				@Override
+				public Mono<Void> error(CreateServiceInstanceBindingRequest request, Throwable t) {
+					return Mono.empty();
+				}
+			};
+		}
+	}
+
+	@TestConfiguration
+	public static class DeleteInstanceBindingEventFlowBeansConfiguration {
+
+		@Bean
+		public DeleteServiceInstanceBindingInitializationFlow createInitFlow() {
+			return new DeleteServiceInstanceBindingInitializationFlow() {
+				@Override
+				public Mono<Void> initialize(DeleteServiceInstanceBindingRequest request) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public DeleteServiceInstanceBindingCompletionFlow createCompleteFlow() {
+			return new DeleteServiceInstanceBindingCompletionFlow() {
+				@Override
+				public Mono<Void> complete(DeleteServiceInstanceBindingRequest request,
+										   DeleteServiceInstanceBindingResponse response) {
+					return Mono.empty();
+				}
+			};
+		}
+
+		@Bean
+		public DeleteServiceInstanceBindingErrorFlow createErrorFlow() {
+			return new DeleteServiceInstanceBindingErrorFlow() {
+				@Override
+				public Mono<Void> error(DeleteServiceInstanceBindingRequest request, Throwable t) {
+					return Mono.empty();
+				}
+			};
+		}
+	}
+
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfigurationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerAutoConfigurationTest.java
@@ -60,9 +60,6 @@ public class ServiceBrokerAutoConfigurationTest {
 					assertThat(context)
 							.getBean(ServiceInstanceService.class)
 							.isExactlyInstanceOf(TestServiceInstanceService.class);
-
-					assertThat(context)
-							.hasSingleBean(EventFlowRegistries.class);
 				});
 	}
 
@@ -82,9 +79,6 @@ public class ServiceBrokerAutoConfigurationTest {
 					assertThat(context)
 							.getBean(ServiceInstanceService.class)
 							.isExactlyInstanceOf(TestServiceInstanceService.class);
-
-					assertThat(context)
-							.hasSingleBean(EventFlowRegistries.class);
 				});
 	}
 
@@ -104,9 +98,6 @@ public class ServiceBrokerAutoConfigurationTest {
 					assertThat(context)
 							.getBean(ServiceInstanceService.class)
 							.isExactlyInstanceOf(TestServiceInstanceService.class);
-
-					assertThat(context)
-							.hasSingleBean(EventFlowRegistries.class);
 				});
 	}
 
@@ -126,9 +117,6 @@ public class ServiceBrokerAutoConfigurationTest {
 					assertThat(context)
 							.getBean(ServiceInstanceService.class)
 							.isExactlyInstanceOf(TestServiceInstanceService.class);
-
-					assertThat(context)
-							.hasSingleBean(EventFlowRegistries.class);
 				});
 	}
 
@@ -200,9 +188,6 @@ public class ServiceBrokerAutoConfigurationTest {
 					assertThat(context)
 							.getBean(ServiceInstanceService.class)
 							.isExactlyInstanceOf(TestServiceInstanceService.class);
-
-					assertThat(context)
-							.hasSingleBean(EventFlowRegistries.class);
 				});
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/AsyncOperationServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/AsyncOperationServiceInstanceEventFlowRegistry.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.service.events;
 
+import java.util.List;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.servicebroker.model.instance.GetLastServiceOperationRequest;
@@ -32,6 +34,17 @@ import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperati
 public class AsyncOperationServiceInstanceEventFlowRegistry extends EventFlowRegistry<AsyncOperationServiceInstanceInitializationFlow,
 		AsyncOperationServiceInstanceCompletionFlow, AsyncOperationServiceInstanceErrorFlow, GetLastServiceOperationRequest,
 		GetLastServiceOperationResponse> {
+
+	@Deprecated
+	public AsyncOperationServiceInstanceEventFlowRegistry() {
+	}
+
+	public AsyncOperationServiceInstanceEventFlowRegistry(
+			final List<AsyncOperationServiceInstanceInitializationFlow> initializationFlows,
+			final List<AsyncOperationServiceInstanceCompletionFlow> completionFlows,
+			final List<AsyncOperationServiceInstanceErrorFlow> errorFlows) {
+		super(initializationFlows, completionFlows, errorFlows);
+	}
 
 	@Override
 	public Flux<Void> getInitializationFlows(GetLastServiceOperationRequest request) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceBindingEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceBindingEventFlowRegistry.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.service.events;
 
+import java.util.List;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingRequest;
@@ -32,6 +34,17 @@ import org.springframework.cloud.servicebroker.service.events.flows.CreateServic
 public class CreateServiceInstanceBindingEventFlowRegistry extends EventFlowRegistry<CreateServiceInstanceBindingInitializationFlow,
 		CreateServiceInstanceBindingCompletionFlow, CreateServiceInstanceBindingErrorFlow, CreateServiceInstanceBindingRequest,
 		CreateServiceInstanceBindingResponse> {
+
+	@Deprecated
+	public CreateServiceInstanceBindingEventFlowRegistry() {
+	}
+
+	public CreateServiceInstanceBindingEventFlowRegistry(
+			final List<CreateServiceInstanceBindingInitializationFlow> initializationFlows,
+			final List<CreateServiceInstanceBindingCompletionFlow> completionFlows,
+			final List<CreateServiceInstanceBindingErrorFlow> errorFlows) {
+		super(initializationFlows, completionFlows, errorFlows);
+	}
 
 	@Override
 	public Flux<Void> getInitializationFlows(CreateServiceInstanceBindingRequest request) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/CreateServiceInstanceEventFlowRegistry.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.service.events;
 
+import java.util.List;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
@@ -32,6 +34,17 @@ import org.springframework.cloud.servicebroker.service.events.flows.CreateServic
 public class CreateServiceInstanceEventFlowRegistry extends EventFlowRegistry<CreateServiceInstanceInitializationFlow,
 		CreateServiceInstanceCompletionFlow, CreateServiceInstanceErrorFlow, CreateServiceInstanceRequest,
 		CreateServiceInstanceResponse> {
+
+	@Deprecated
+	public CreateServiceInstanceEventFlowRegistry() {
+	}
+
+	public CreateServiceInstanceEventFlowRegistry(
+			final List<CreateServiceInstanceInitializationFlow> initializationFlows,
+			final List<CreateServiceInstanceCompletionFlow> completionFlows,
+			final List<CreateServiceInstanceErrorFlow> errorFlows) {
+		super(initializationFlows, completionFlows, errorFlows);
+	}
 
 	@Override
 	public Flux<Void> getInitializationFlows(CreateServiceInstanceRequest request) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceBindingEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceBindingEventFlowRegistry.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.service.events;
 
+import java.util.List;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingRequest;
@@ -32,6 +34,17 @@ import org.springframework.cloud.servicebroker.service.events.flows.DeleteServic
 public class DeleteServiceInstanceBindingEventFlowRegistry extends EventFlowRegistry<DeleteServiceInstanceBindingInitializationFlow,
 		DeleteServiceInstanceBindingCompletionFlow, DeleteServiceInstanceBindingErrorFlow, DeleteServiceInstanceBindingRequest,
 		DeleteServiceInstanceBindingResponse> {
+
+	@Deprecated
+	public DeleteServiceInstanceBindingEventFlowRegistry() {
+	}
+
+	public DeleteServiceInstanceBindingEventFlowRegistry(
+			final List<DeleteServiceInstanceBindingInitializationFlow> initializationFlows,
+			final List<DeleteServiceInstanceBindingCompletionFlow> completionFlows,
+			final List<DeleteServiceInstanceBindingErrorFlow> errorFlows) {
+		super(initializationFlows, completionFlows, errorFlows);
+	}
 
 	@Override
 	public Flux<Void> getInitializationFlows(DeleteServiceInstanceBindingRequest request) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/DeleteServiceInstanceEventFlowRegistry.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.service.events;
 
+import java.util.List;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
@@ -32,6 +34,17 @@ import org.springframework.cloud.servicebroker.service.events.flows.DeleteServic
 public class DeleteServiceInstanceEventFlowRegistry extends EventFlowRegistry<DeleteServiceInstanceInitializationFlow,
 		DeleteServiceInstanceCompletionFlow, DeleteServiceInstanceErrorFlow, DeleteServiceInstanceRequest,
 		DeleteServiceInstanceResponse> {
+
+	@Deprecated
+	public DeleteServiceInstanceEventFlowRegistry() {
+	}
+
+	public DeleteServiceInstanceEventFlowRegistry(
+			final List<DeleteServiceInstanceInitializationFlow> initializationFlows,
+			final List<DeleteServiceInstanceCompletionFlow> completionFlows,
+			final List<DeleteServiceInstanceErrorFlow> errorFlows) {
+		super(initializationFlows, completionFlows, errorFlows);
+	}
 
 	@Override
 	public Flux<Void> getInitializationFlows(DeleteServiceInstanceRequest request) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistries.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistries.java
@@ -35,6 +35,7 @@ public class EventFlowRegistries {
 
 	private DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry;
 
+	@Deprecated
 	public EventFlowRegistries() {
 		this.createInstanceRegistry = new CreateServiceInstanceEventFlowRegistry();
 		this.updateInstanceRegistry = new UpdateServiceInstanceEventFlowRegistry();
@@ -42,6 +43,20 @@ public class EventFlowRegistries {
 		this.asyncOperationRegistry = new AsyncOperationServiceInstanceEventFlowRegistry();
 		this.createInstanceBindingRegistry = new CreateServiceInstanceBindingEventFlowRegistry();
 		this.deleteInstanceBindingRegistry = new DeleteServiceInstanceBindingEventFlowRegistry();
+	}
+
+	public EventFlowRegistries(CreateServiceInstanceEventFlowRegistry createInstanceRegistry,
+							   UpdateServiceInstanceEventFlowRegistry updateInstanceRegistry,
+							   DeleteServiceInstanceEventFlowRegistry deleteInstanceRegistry,
+							   AsyncOperationServiceInstanceEventFlowRegistry asyncOperationRegistry,
+							   CreateServiceInstanceBindingEventFlowRegistry createInstanceBindingRegistry,
+							   DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry) {
+		this.createInstanceRegistry = createInstanceRegistry;
+		this.updateInstanceRegistry = updateInstanceRegistry;
+		this.deleteInstanceRegistry = deleteInstanceRegistry;
+		this.asyncOperationRegistry = asyncOperationRegistry;
+		this.createInstanceBindingRegistry = createInstanceBindingRegistry;
+		this.deleteInstanceBindingRegistry = deleteInstanceBindingRegistry;
 	}
 
 	public CreateServiceInstanceEventFlowRegistry getCreateInstanceRegistry() {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/UpdateServiceInstanceEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/UpdateServiceInstanceEventFlowRegistry.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.service.events;
 
+import java.util.List;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
@@ -27,6 +29,17 @@ import org.springframework.cloud.servicebroker.service.events.flows.UpdateServic
 public class UpdateServiceInstanceEventFlowRegistry extends EventFlowRegistry<UpdateServiceInstanceInitializationFlow,
 		UpdateServiceInstanceCompletionFlow, UpdateServiceInstanceErrorFlow, UpdateServiceInstanceRequest,
 		UpdateServiceInstanceResponse> {
+
+	@Deprecated
+	public UpdateServiceInstanceEventFlowRegistry() {
+	}
+
+	public UpdateServiceInstanceEventFlowRegistry(
+			final List<UpdateServiceInstanceInitializationFlow> initializationFlows,
+			final List<UpdateServiceInstanceCompletionFlow> completionFlows,
+			final List<UpdateServiceInstanceErrorFlow> errorFlows) {
+		super(initializationFlows, completionFlows, errorFlows);
+	}
 
 	@Override
 	public Flux<Void> getInitializationFlows(UpdateServiceInstanceRequest request) {

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventServiceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventServiceTest.java
@@ -42,6 +42,7 @@ import org.springframework.cloud.servicebroker.service.events.flows.DeleteServic
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 public class ServiceInstanceBindingEventServiceTest {
 
 	private TestServiceInstanceBindingService serviceInstanceBindingService;

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceEventServiceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceEventServiceTest.java
@@ -47,6 +47,7 @@ import org.springframework.cloud.servicebroker.service.events.flows.UpdateServic
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 public class ServiceInstanceEventServiceTest {
 
 	private TestServiceInstanceService serviceInstanceService;
@@ -160,7 +161,7 @@ public class ServiceInstanceEventServiceTest {
 									DeleteServiceInstanceResponse response) {
 								return results.setAfterDelete("after " + request.getServiceInstanceId());
 							}
-				}))
+						}))
 				.then(eventFlowRegistries.getDeleteInstanceRegistry()
 						.addErrorFlow(new DeleteServiceInstanceErrorFlow() {
 							@Override
@@ -242,8 +243,8 @@ public class ServiceInstanceEventServiceTest {
 		StepVerifier
 				.create(serviceInstanceEventService.updateServiceInstance(
 						UpdateServiceInstanceRequest.builder()
-						.serviceInstanceId("foo")
-						.build()))
+								.serviceInstanceId("foo")
+								.build()))
 				.expectError()
 				.verify();
 


### PR DESCRIPTION
This commit exposes a number of auto-configured beans, by which the individual
event flows may be registered. It is no longer required to access or set the
flows through the various registries within the `EventFlowRegistries` bean.

Resolves #124