### PR TITLE
Change response codes to confrom to OSB API spec

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidPar
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerOperationInProgressException;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerUnavailableException;
 import org.springframework.cloud.servicebroker.exception.ServiceDefinitionDoesNotExistException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
@@ -165,6 +166,12 @@ public class ServiceBrokerExceptionHandler {
 	@ExceptionHandler(ServiceInstanceBindingExistsException.class)
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ErrorMessage handleException(ServiceInstanceBindingExistsException ex) {
+		return getErrorResponse(ex);
+	}
+
+	@ExceptionHandler(ServiceInstanceBindingDoesNotExistException.class)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	public ErrorMessage handleException(ServiceInstanceBindingDoesNotExistException ex) {
 		return getErrorResponse(ex);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -141,7 +141,15 @@ public class ServiceInstanceBindingController extends BaseController {
 						.doOnRequest(v -> logger.debug("Getting a service instance binding: request={}", req))
 						.doOnSuccess(response -> logger.debug("Getting a service instance binding succeeded: bindingId={}", bindingId)))
 				.map(response -> new ResponseEntity<>(response, HttpStatus.OK))
-				.switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.OK)));
+				.switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.OK)))
+				.onErrorResume(e -> {
+					if (e instanceof ServiceInstanceBindingDoesNotExistException) {
+						return Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+					}
+					else {
+						return Mono.error(e);
+					}
+				});
 	}
 
 	@GetMapping(value = {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
@@ -140,7 +140,15 @@ public class ServiceInstanceController extends BaseController {
 						.doOnSuccess(response -> logger.debug("Getting service instance succeeded: serviceInstanceId={}, response={}",
 								serviceInstanceId, response)))
 				.map(response -> new ResponseEntity<>(response, HttpStatus.OK))
-				.switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.OK)));
+				.switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.OK)))
+				.onErrorResume(e -> {
+					if (e instanceof ServiceInstanceDoesNotExistException) {
+						return Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+					}
+					else {
+						return Mono.error(e);
+					}
+				});
 	}
 
 	@GetMapping(value = {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceBindingDoesNotExistException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceInstanceBindingDoesNotExistException.java
@@ -20,7 +20,7 @@ package org.springframework.cloud.servicebroker.exception;
  * Thrown to indicate that a request includes a service binding ID that is not known to the service broker.
  *
  * <p>
- * Throwing this exception will result in an HTTP status code {@literal 410 GONE}
+ * Throwing this exception will result in an HTTP status code {@literal 422 UNPROCESSABLE ENTITY}
  * being returned to the platform.
  */
 public class ServiceInstanceBindingDoesNotExistException extends RuntimeException {

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
@@ -32,6 +32,7 @@ import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidPar
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerOperationInProgressException;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerUnavailableException;
 import org.springframework.cloud.servicebroker.exception.ServiceDefinitionDoesNotExistException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
@@ -254,6 +255,16 @@ public class ServiceBrokerExceptionHandlerTest {
 		assertThat(errorMessage.getMessage())
 				.contains("serviceInstanceId=service-instance-id")
 				.contains("bindingId=binding-id");
+	}
+
+	@Test
+	public void bindingDoesNotExistException() {
+		ErrorMessage errorMessage = exceptionHandler
+				.handleException(new ServiceInstanceBindingDoesNotExistException("binding-id"));
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage())
+				.contains("id=binding-id");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
@@ -182,6 +182,18 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 		assertThat(responseEntity.getBody()).isEqualTo(data.response);
 	}
 
+	@Test
+	public void getServiceBindingWithMissingBindingGivesExpectedStatus() {
+		doThrow(new ServiceInstanceBindingDoesNotExistException("binding-id"))
+				.when(bindingService).getServiceInstanceBinding(any(GetServiceInstanceBindingRequest.class));
+
+		ResponseEntity<GetServiceInstanceBindingResponse> responseEntity = controller
+				.getServiceInstanceBinding(pathVariables, null, null, null, null)
+				.block();
+
+		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
 	@Theory
 	public void deleteServiceBindingWithResponseGivesExpectedStatus(DeleteResponseAndExpectedStatus data) {
 		Mono<DeleteServiceInstanceBindingResponse> responseMono;

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
@@ -256,6 +256,18 @@ public class ServiceInstanceControllerResponseCodeTest {
 		assertThat(responseEntity.getBody()).isEqualTo(data.response);
 	}
 
+	@Test
+	public void getServiceInstanceWithMissingInstanceGivesExpectedStatus() {
+		when(serviceInstanceService.getServiceInstance(any(GetServiceInstanceRequest.class)))
+				.thenReturn(Mono.error(new ServiceInstanceDoesNotExistException("instance does not exist")));
+
+		ResponseEntity<GetServiceInstanceResponse> responseEntity = controller
+				.getServiceInstance(pathVariables, null, "service-definition-id", null)
+				.block();
+
+		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
 	@Theory
 	public void deleteServiceInstanceWithResponseGivesExpectedStatus(DeleteResponseAndExpectedStatus data) {
 		Mono<DeleteServiceInstanceResponse> responseMono;


### PR DESCRIPTION
Fixes #211

In order to see clearly the picture of what responses there are now and which there should be, I created tables, which can be seen below. Those current responses, which needed to be (and has been) changed are marked with **bold** in tables.

For some cases the specification does not explisitly state what response codes there should be (marked as *unspecified* in table). Fixing the issue, I tried to conform to the current desing decisions. So, for those *unspecified* response codes I've left current `422`, that's why I've made `ServiceInstanceBindingDoesNotExistException` to be mapped to `422` by default (see `/last_operation` in table 3).

Table 1. Endpoint: `service_instances/<not_existing_instance_id>`

| Request        | Response By SPEC  |  Current Response  |  Exception |
|:--------------:|:---------------------:|:---------------------:|:------------:|
| GET | 404 | **422** | ServiceInstanceDoesNotExistException |
| PATCH | *unspecified* | 422 | ServiceInstanceDoesNotExistException |
| DELETE | 410	| **422** | ServiceInstanceDoesNotExistException |
| GET /last_operation | *unspecified*| 422 | ServiceInstanceDoesNotExistException |

Table 2. Endpoint: `service_instances/<not_existing_instance_id>/service_bindings/<some_binding_id>`

| Request        | Response By SPEC  |  Current Response  |  Exception |
|:--------------:|:---------------------:|:---------------------:|:------------:|
| PUT | *unspecified* | 422 | ServiceInstanceDoesNotExistException |
| GET | *unspecified* | 422 | ServiceInstanceDoesNotExistException |
| DELETE | *unspecified* | 422 | ServiceInstanceDoesNotExistException |
| GET /last_operation | *unspecified* | 422 | ServiceInstanceDoesNotExistException |

Table 3. Endpoint: `service_instances/<some_existing_instance_id>/service_bindings/<not_existing_binding_id>`

| Request        | Response By SPEC  |  Current Response  |  Exception |
|:--------------:|:---------------------:|:---------------------:|:------------:|
| GET | 404 | **500** | ServiceInstanceBindingDoesNotExistException (it's not mapped) |
| DELETE | 410 | 410 | ServiceInstanceBindingDoesNotExistException |
| GET /last_operation | *unspecified* | **500** | *always* UnsupportedOperationException (see  #213 ) |
