### PR TITLE
Add support for binding get last operation

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/EventFlowsAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/EventFlowsAutoConfiguration.java
@@ -18,6 +18,10 @@ package org.springframework.cloud.servicebroker.autoconfigure.web;
 
 import java.util.List;
 
+import org.springframework.cloud.servicebroker.service.events.AsyncOperationServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingInitializationFlow;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -122,6 +126,15 @@ public class EventFlowsAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(AsyncOperationServiceInstanceBindingEventFlowRegistry.class)
+	public AsyncOperationServiceInstanceBindingEventFlowRegistry asyncOperationBindingRegistry(
+			@Autowired(required = false) List<AsyncOperationServiceInstanceBindingInitializationFlow> initializationFlows,
+			@Autowired(required = false) List<AsyncOperationServiceInstanceBindingCompletionFlow> completionFlows,
+			@Autowired(required = false) List<AsyncOperationServiceInstanceBindingErrorFlow> errorFlows) {
+		return new AsyncOperationServiceInstanceBindingEventFlowRegistry(initializationFlows, completionFlows, errorFlows);
+	}
+
+	@Bean
 	@ConditionalOnMissingBean(EventFlowRegistries.class)
 	public EventFlowRegistries eventFlowRegistries(
 			CreateServiceInstanceEventFlowRegistry createInstanceRegistry,
@@ -129,9 +142,11 @@ public class EventFlowsAutoConfiguration {
 			DeleteServiceInstanceEventFlowRegistry deleteInstanceRegistry,
 			AsyncOperationServiceInstanceEventFlowRegistry asyncOperationRegistry,
 			CreateServiceInstanceBindingEventFlowRegistry createInstanceBindingRegistry,
-			DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry) {
+			DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry,
+			AsyncOperationServiceInstanceBindingEventFlowRegistry asyncOperationBindingRegistry) {
 		return new EventFlowRegistries(createInstanceRegistry, updateInstanceRegistry, deleteInstanceRegistry,
-				asyncOperationRegistry, createInstanceBindingRegistry, deleteInstanceBindingRegistry);
+				asyncOperationRegistry, createInstanceBindingRegistry,
+				deleteInstanceBindingRegistry, asyncOperationBindingRegistry);
 	}
 
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,7 +3,8 @@ org.springframework.cloud.servicebroker.autoconfigure.web.ServiceBrokerAutoConfi
 org.springframework.cloud.servicebroker.autoconfigure.web.servlet.ServiceBrokerWebMvcAutoConfiguration,\
 org.springframework.cloud.servicebroker.autoconfigure.web.servlet.ApiVersionWebMvcAutoConfiguration,\
 org.springframework.cloud.servicebroker.autoconfigure.web.reactive.ServiceBrokerWebFluxAutoConfiguration,\
-org.springframework.cloud.servicebroker.autoconfigure.web.reactive.ApiVersionWebFluxAutoConfiguration
+org.springframework.cloud.servicebroker.autoconfigure.web.reactive.ApiVersionWebFluxAutoConfiguration,\
+org.springframework.cloud.servicebroker.autoconfigure.web.EventFlowsAutoConfiguration
 
 org.springframework.boot.diagnostics.FailureAnalyzer=\
 org.springframework.cloud.servicebroker.autoconfigure.web.RequiredCatalogBeanFailureAnalyzer,\

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/AsyncOperationServiceInstanceBindingEventFlowRegistry.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/AsyncOperationServiceInstanceBindingEventFlowRegistry.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.service.events;
+
+import java.util.List;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationResponse;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingInitializationFlow;
+
+/**
+ * Event flow registry for asynchronous get last binding operation requests.
+ *
+ * @author ilyavy
+ */
+public class AsyncOperationServiceInstanceBindingEventFlowRegistry
+        extends EventFlowRegistry<AsyncOperationServiceInstanceBindingInitializationFlow,
+        AsyncOperationServiceInstanceBindingCompletionFlow, AsyncOperationServiceInstanceBindingErrorFlow,
+        GetLastServiceBindingOperationRequest, GetLastServiceBindingOperationResponse> {
+
+    public AsyncOperationServiceInstanceBindingEventFlowRegistry(
+            final List<AsyncOperationServiceInstanceBindingInitializationFlow> initializationFlows,
+            final List<AsyncOperationServiceInstanceBindingCompletionFlow> completionFlows,
+            final List<AsyncOperationServiceInstanceBindingErrorFlow> errorFlows) {
+        super(initializationFlows, completionFlows, errorFlows);
+    }
+
+    @Override
+    public Flux<Void> getInitializationFlows(GetLastServiceBindingOperationRequest request) {
+        return getInitializationFlowsInternal()
+                .flatMap(flow -> flow.initialize(request));
+    }
+
+    @Override
+    public Flux<Void> getCompletionFlows(
+            GetLastServiceBindingOperationRequest request, GetLastServiceBindingOperationResponse response) {
+
+        return getCompletionFlowsInternal()
+                .flatMap(flow -> flow.complete(request, response));
+    }
+
+    @Override
+    public Flux<Void> getErrorFlows(GetLastServiceBindingOperationRequest request, Throwable t) {
+        return getErrorFlowsInternal()
+                .flatMap(flow -> flow.error(request, t));
+    }
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistries.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/EventFlowRegistries.java
@@ -35,6 +35,8 @@ public class EventFlowRegistries {
 
 	private DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry;
 
+    private AsyncOperationServiceInstanceBindingEventFlowRegistry asyncOperationBindingRegistry;
+
 	@Deprecated
 	public EventFlowRegistries() {
 		this.createInstanceRegistry = new CreateServiceInstanceEventFlowRegistry();
@@ -50,13 +52,15 @@ public class EventFlowRegistries {
 							   DeleteServiceInstanceEventFlowRegistry deleteInstanceRegistry,
 							   AsyncOperationServiceInstanceEventFlowRegistry asyncOperationRegistry,
 							   CreateServiceInstanceBindingEventFlowRegistry createInstanceBindingRegistry,
-							   DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry) {
+							   DeleteServiceInstanceBindingEventFlowRegistry deleteInstanceBindingRegistry,
+                               AsyncOperationServiceInstanceBindingEventFlowRegistry asyncOperationBindingRegistry) {
 		this.createInstanceRegistry = createInstanceRegistry;
 		this.updateInstanceRegistry = updateInstanceRegistry;
 		this.deleteInstanceRegistry = deleteInstanceRegistry;
 		this.asyncOperationRegistry = asyncOperationRegistry;
 		this.createInstanceBindingRegistry = createInstanceBindingRegistry;
 		this.deleteInstanceBindingRegistry = deleteInstanceBindingRegistry;
+		this.asyncOperationBindingRegistry = asyncOperationBindingRegistry;
 	}
 
 	public CreateServiceInstanceEventFlowRegistry getCreateInstanceRegistry() {
@@ -81,6 +85,10 @@ public class EventFlowRegistries {
 
 	public DeleteServiceInstanceBindingEventFlowRegistry getDeleteInstanceBindingRegistry() {
 		return deleteInstanceBindingRegistry;
+	}
+
+	public AsyncOperationServiceInstanceBindingEventFlowRegistry getAsyncOperationBindingRegistry() {
+		return asyncOperationBindingRegistry;
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingCompletionFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingCompletionFlow.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.service.events.flows;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationResponse;
+
+/**
+ * Completion flow for service binding asynchronous get last operation request.
+ *
+ * @author ilyavy
+ */
+public interface AsyncOperationServiceInstanceBindingCompletionFlow {
+
+	default Mono<Void> complete(GetLastServiceBindingOperationRequest request, GetLastServiceBindingOperationResponse response) {
+		return Mono.empty();
+	}
+
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingErrorFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingErrorFlow.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.service.events.flows;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+
+/**
+ * Error flow for service binding asynchronous get last operation request.
+ *
+ * @author ilyavy
+ */
+public interface AsyncOperationServiceInstanceBindingErrorFlow {
+
+	default Mono<Void> error(GetLastServiceBindingOperationRequest request, Throwable t) {
+		return Mono.empty();
+	}
+
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingInitializationFlow.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingInitializationFlow.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.service.events.flows;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+
+/**
+ * Initialization flow for service binding asynchronous get last operation request.
+ *
+ * @author ilyavy
+ */
+public interface AsyncOperationServiceInstanceBindingInitializationFlow {
+
+	default Mono<Void> initialize(GetLastServiceBindingOperationRequest request) {
+		return Mono.empty();
+	}
+
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventServiceTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingEventServiceTest.java
@@ -16,11 +16,14 @@
 
 package org.springframework.cloud.servicebroker.service;
 
+import java.util.ArrayList;
+
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidParametersException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
@@ -29,10 +32,22 @@ import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstan
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingResponse;
 import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingResponse;
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationResponse;
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingResponse;
+import org.springframework.cloud.servicebroker.service.events.AsyncOperationServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.AsyncOperationServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.CreateServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.CreateServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.DeleteServiceInstanceBindingEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.DeleteServiceInstanceEventFlowRegistry;
 import org.springframework.cloud.servicebroker.service.events.EventFlowRegistries;
+import org.springframework.cloud.servicebroker.service.events.UpdateServiceInstanceEventFlowRegistry;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingCompletionFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingErrorFlow;
+import org.springframework.cloud.servicebroker.service.events.flows.AsyncOperationServiceInstanceBindingInitializationFlow;
 import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingCompletionFlow;
 import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingErrorFlow;
 import org.springframework.cloud.servicebroker.service.events.flows.CreateServiceInstanceBindingInitializationFlow;
@@ -42,7 +57,6 @@ import org.springframework.cloud.servicebroker.service.events.flows.DeleteServic
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("deprecation")
 public class ServiceInstanceBindingEventServiceTest {
 
 	private TestServiceInstanceBindingService serviceInstanceBindingService;
@@ -56,7 +70,20 @@ public class ServiceInstanceBindingEventServiceTest {
 	@Before
 	public void setUp() {
 		this.serviceInstanceBindingService = new TestServiceInstanceBindingService();
-		this.eventFlowRegistries = new EventFlowRegistries();
+		this.eventFlowRegistries = new EventFlowRegistries(
+				new CreateServiceInstanceEventFlowRegistry(new ArrayList<>(), new ArrayList<>(), new ArrayList<>()),
+				new UpdateServiceInstanceEventFlowRegistry(new ArrayList<>(), new ArrayList<>(), new ArrayList<>()),
+				new DeleteServiceInstanceEventFlowRegistry(new ArrayList<>(), new ArrayList<>(), new ArrayList<>()),
+				new AsyncOperationServiceInstanceEventFlowRegistry(
+						new ArrayList<>(), new ArrayList<>(), new ArrayList<>()),
+				new CreateServiceInstanceBindingEventFlowRegistry(
+						new ArrayList<>(), new ArrayList<>(), new ArrayList<>()),
+				new DeleteServiceInstanceBindingEventFlowRegistry(
+						new ArrayList<>(), new ArrayList<>(), new ArrayList<>()),
+				new AsyncOperationServiceInstanceBindingEventFlowRegistry(
+						new ArrayList<>(), new ArrayList<>(), new ArrayList<>())
+		);
+
 		this.serviceInstanceBindingEventService =
 				new ServiceInstanceBindingEventService(serviceInstanceBindingService, eventFlowRegistries);
 		this.results = new EventFlowTestResults();
@@ -113,6 +140,69 @@ public class ServiceInstanceBindingEventServiceTest {
 								.build()))
 				.expectNext(GetServiceInstanceAppBindingResponse.builder().build())
 				.verifyComplete();
+	}
+
+	@Test
+	public void getLastOperationSucceeds() {
+		prepareLastOperationEventFlows();
+
+		StepVerifier
+				.create(serviceInstanceBindingEventService.getLastOperation(
+						GetLastServiceBindingOperationRequest.builder()
+								.bindingId("foo")
+								.serviceInstanceId("bar")
+								.build()))
+				.expectNext(GetLastServiceBindingOperationResponse.builder().build())
+				.verifyComplete();
+
+		assertThat(this.results.getBeforeLastOperation()).isEqualTo("before foo");
+		assertThat(this.results.getAfterLastOperation()).isEqualTo("after foo");
+		assertThat(this.results.getErrorLastOperation()).isNullOrEmpty();
+	}
+
+	@Test
+	public void getLastOperationFails() {
+		prepareLastOperationEventFlows();
+
+		StepVerifier
+				.create(serviceInstanceBindingEventService.getLastOperation(
+						GetLastServiceBindingOperationRequest.builder()
+								.bindingId("foo")
+								.build()))
+				.expectError()
+				.verify();
+
+		assertThat(this.results.getBeforeLastOperation()).isEqualTo("before foo");
+		assertThat(this.results.getAfterLastOperation()).isNullOrEmpty();
+		assertThat(this.results.getErrorLastOperation()).isEqualTo("error foo");
+	}
+
+	private void prepareLastOperationEventFlows() {
+		this.eventFlowRegistries.getAsyncOperationBindingRegistry()
+				.addInitializationFlow(new AsyncOperationServiceInstanceBindingInitializationFlow() {
+					@Override
+					public Mono<Void> initialize(GetLastServiceBindingOperationRequest request) {
+						return results.setBeforeLastOperation("before " + request.getBindingId());
+					}
+				})
+				.then(this.eventFlowRegistries.getAsyncOperationBindingRegistry()
+						.addCompletionFlow(new AsyncOperationServiceInstanceBindingCompletionFlow() {
+							@Override
+							public Mono<Void> complete(
+									GetLastServiceBindingOperationRequest request,
+									GetLastServiceBindingOperationResponse response) {
+								return results.setAfterLastOperation("after " + request.getBindingId());
+							}
+						}))
+				.then(eventFlowRegistries.getAsyncOperationBindingRegistry()
+						.addErrorFlow(new AsyncOperationServiceInstanceBindingErrorFlow() {
+							@Override
+							public Mono<Void> error(GetLastServiceBindingOperationRequest request,
+													Throwable t) {
+								return results.setErrorLastOperation("error " + request.getBindingId());
+							}
+						}))
+				.subscribe();
 	}
 
 	@Test
@@ -229,6 +319,13 @@ public class ServiceInstanceBindingEventServiceTest {
 			return Mono.just(DeleteServiceInstanceBindingResponse.builder().build());
 		}
 
+		@Override
+		public Mono<GetLastServiceBindingOperationResponse> getLastOperation(GetLastServiceBindingOperationRequest request) {
+			if (request.getServiceInstanceId() == null) {
+				return Mono.error(new ServiceBrokerInvalidParametersException("service instance id cannot be null"));
+			}
+			return Mono.just(GetLastServiceBindingOperationResponse.builder().build());
+		}
 	}
 
 	private static class EventFlowTestResults {
@@ -244,6 +341,12 @@ public class ServiceInstanceBindingEventServiceTest {
 		private String afterDelete = null;
 
 		private String errorDelete = null;
+
+		private String beforeLastOperation = null;
+
+		private String afterLastOperation = null;
+
+		private String errorLastOperation = null;
 
 		String getBeforeCreate() {
 			return beforeCreate;
@@ -296,6 +399,33 @@ public class ServiceInstanceBindingEventServiceTest {
 
 		public Mono<Void> setErrorDelete(String errorDelete) {
 			return Mono.fromCallable(() -> this.errorDelete = errorDelete)
+					.then();
+		}
+
+		String getBeforeLastOperation() {
+			return beforeLastOperation;
+		}
+
+		Mono<Void> setBeforeLastOperation(String s) {
+			return Mono.fromCallable(() -> this.beforeLastOperation = s)
+					.then();
+		}
+
+		String getAfterLastOperation() {
+			return afterLastOperation;
+		}
+
+		Mono<Void> setAfterLastOperation(String s) {
+			return Mono.fromCallable(() -> this.afterLastOperation = s)
+					.then();
+		}
+
+		String getErrorLastOperation() {
+			return errorLastOperation;
+		}
+
+		Mono<Void> setErrorLastOperation(String s) {
+			return Mono.fromCallable(() -> this.errorLastOperation = s)
 					.then();
 		}
 	}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingCompletionFlowTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingCompletionFlowTest.java
@@ -1,0 +1,23 @@
+package org.springframework.cloud.servicebroker.service.events.flows;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationResponse;
+
+import static org.mockito.Mockito.mock;
+
+class AsyncOperationServiceInstanceBindingCompletionFlowTest {
+
+    @Test
+    void complete() {
+        AsyncOperationServiceInstanceBindingCompletionFlow flow =
+                new AsyncOperationServiceInstanceBindingCompletionFlow() {};
+        StepVerifier.create(
+                flow.complete(
+                        mock(GetLastServiceBindingOperationRequest.class),
+                        mock(GetLastServiceBindingOperationResponse.class)))
+                .verifyComplete();
+    }
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingErrorFlowTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingErrorFlowTest.java
@@ -1,0 +1,20 @@
+package org.springframework.cloud.servicebroker.service.events.flows;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+
+import static org.mockito.Mockito.mock;
+
+class AsyncOperationServiceInstanceBindingErrorFlowTest {
+
+    @Test
+    void error() {
+        AsyncOperationServiceInstanceBindingErrorFlow flow =
+                new AsyncOperationServiceInstanceBindingErrorFlow() {};
+        StepVerifier.create(
+                flow.error(mock(GetLastServiceBindingOperationRequest.class), mock(Exception.class)))
+                .verifyComplete();
+    }
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingInitializationFlowTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/service/events/flows/AsyncOperationServiceInstanceBindingInitializationFlowTest.java
@@ -1,0 +1,20 @@
+package org.springframework.cloud.servicebroker.service.events.flows;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.servicebroker.model.binding.GetLastServiceBindingOperationRequest;
+
+import static org.mockito.Mockito.mock;
+
+class AsyncOperationServiceInstanceBindingInitializationFlowTest {
+
+    @Test
+    void initialize() {
+        AsyncOperationServiceInstanceBindingInitializationFlow flow =
+                new AsyncOperationServiceInstanceBindingInitializationFlow() {};
+        StepVerifier
+                .create(flow.initialize(mock(GetLastServiceBindingOperationRequest.class)))
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
Fixes #213

Branched from `master` because of the commit [Support auto-configuration of event flows](https://github.com/spring-cloud/spring-cloud-open-service-broker/commit/04135a54a93147117319cc4c0e58e7d3988e607f) to use the changes it has introduced.

To fix the issue, implemented flows approach similar to service instance get last operation flows, updated tests, enabled `EventFlowsAutoConfiguration` by adding it to `spring.factories`.