### PR TITLE
Change exceptions mapping to conform spec

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
@@ -314,7 +314,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends AbstractSer
 				.content(body)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(request().asyncNotStarted())
-				.andExpect(status().isUnprocessableEntity())
+				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.description", containsString("serviceDefinitionId")));
 	}
 
@@ -327,7 +327,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends AbstractSer
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(request().asyncNotStarted())
-				.andExpect(status().isUnprocessableEntity())
+				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.description", containsString("serviceDefinitionId")))
 				.andExpect(jsonPath("$.description", containsString("planId")));
 	}
@@ -519,6 +519,19 @@ public class ServiceInstanceBindingControllerIntegrationTest extends AbstractSer
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void deleteBindingWithMissingQueryParamsFails() throws Exception {
+		setupCatalogService(null);
+
+		final String url = buildDeleteUrl(null, false).replace("plan_id", "foo");
+
+		MvcResult mvcResult = mockMvc.perform(delete(url)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.description", containsString("plan_id")))
+				.andReturn();
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -336,7 +336,7 @@ public class ServiceInstanceControllerIntegrationTest extends AbstractServiceIns
 				.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
-				.andExpect(status().isUnprocessableEntity())
+				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.description", containsString("serviceDefinitionId")))
 				.andExpect(request().asyncNotStarted())
 				.andReturn();
@@ -352,7 +352,7 @@ public class ServiceInstanceControllerIntegrationTest extends AbstractServiceIns
 				.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
-				.andExpect(status().isUnprocessableEntity())
+				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.description", containsString("serviceDefinitionId")))
 				.andExpect(jsonPath("$.description", containsString("planId")))
 				.andExpect(request().asyncNotStarted())
@@ -493,6 +493,19 @@ public class ServiceInstanceControllerIntegrationTest extends AbstractServiceIns
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isUnprocessableEntity())
 				.andExpect(jsonPath("$.description", containsString(serviceDefinition.getId())));
+	}
+
+	@Test
+	public void deleteServiceInstanceWithMissingQueryParamsFails() throws Exception {
+		setupCatalogService(null);
+
+		final String url = buildDeleteUrl(null, false).replace("plan_id", "foo");
+
+		MvcResult mvcResult = mockMvc.perform(delete(url)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.description", containsString("plan_id")))
+				.andReturn();
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/build.gradle
+++ b/spring-cloud-open-service-broker-core/build.gradle
@@ -28,6 +28,7 @@ ext {
 	hamcrestVersion = "1.3"
 	jsonPathVersion = "2.4.0"
 	equalsVerifierVersion = "2.4.1"
+	javaxServletApiVersion = "3.1.0"
 }
 
 dependencyManagement {
@@ -64,6 +65,8 @@ dependencies {
 	testImplementation("org.mockito:mockito-core:${mockitoVersion}")
 	testImplementation("com.jayway.jsonpath:json-path:${jsonPathVersion}")
 	testImplementation("nl.jqno.equalsverifier:equalsverifier:${equalsVerifierVersion}")
+	compileOnly("javax.servlet:javax.servlet-api:${javaxServletApiVersion}")
+	testCompile("javax.servlet:javax.servlet-api:${javaxServletApiVersion}")
 }
 
 test {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -41,6 +41,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -122,7 +123,7 @@ public class ServiceBrokerExceptionHandler {
 
 	// Spring WebMVC throws this exception
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ErrorMessage handleException(MethodArgumentNotValidException ex) {
 		return handleBindingException(ex, ex.getBindingResult());
 	}
@@ -141,6 +142,14 @@ public class ServiceBrokerExceptionHandler {
 			message.append(' ').append(error.getField());
 		}
 		return getErrorResponse(message.toString());
+	}
+
+	// Spring WebMVC throws this exception
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorMessage handleException(MissingServletRequestParameterException ex) {
+		logger.error("Unprocessable request received: ", ex);
+		return getErrorResponse(ex.getMessage());
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
@@ -42,6 +42,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.MapBindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.support.WebExchangeBindException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -222,6 +223,21 @@ public class ServiceBrokerExceptionHandlerTest {
 		assertThat(errorMessage.getError()).isNull();
 		assertThat(errorMessage.getMessage()).contains("field1");
 		assertThat(errorMessage.getMessage()).contains("field2");
+	}
+
+	@Test
+	public void stringParameterIsNotPresent() {
+		final String parameterType = "String";
+		final String parameterName = "plan_id";
+
+		MissingServletRequestParameterException exception =
+				new MissingServletRequestParameterException(parameterName, parameterType);
+
+		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
+
+		assertThat(errorMessage.getError()).isNull();
+		assertThat(errorMessage.getMessage()).contains(parameterType);
+		assertThat(errorMessage.getMessage()).contains(parameterName);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #215

The changes relate only to `MethodArgumentNotValidException` and `MissingServletRequestParameterException`.
