### PR TITLE
Change a response code to conform to the OSB API while fetching service bindings

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -21,6 +21,7 @@ import javax.validation.Valid;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.servicebroker.annotation.ServiceBrokerRestController;
@@ -143,7 +144,8 @@ public class ServiceInstanceBindingController extends BaseController {
 				.map(response -> new ResponseEntity<>(response, HttpStatus.OK))
 				.switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.OK)))
 				.onErrorResume(e -> {
-					if (e instanceof ServiceInstanceBindingDoesNotExistException) {
+					if (e instanceof ServiceInstanceBindingDoesNotExistException ||
+							e instanceof ServiceInstanceDoesNotExistException) {
 						return Mono.just(new ResponseEntity<>(HttpStatus.NOT_FOUND));
 					}
 					else {

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
@@ -27,6 +27,7 @@ import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
@@ -189,6 +190,18 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 
 		ResponseEntity<GetServiceInstanceBindingResponse> responseEntity = controller
 				.getServiceInstanceBinding(pathVariables, null, null, null, null)
+				.block();
+
+		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	public void getServiceBindingWithMissingServiceInstanceGivesExpectedStatus() {
+		doThrow(new ServiceInstanceDoesNotExistException("nonexistent-service-id"))
+				.when(bindingService).getServiceInstanceBinding(any(GetServiceInstanceBindingRequest.class));
+
+		ResponseEntity<GetServiceInstanceBindingResponse> responseEntity = controller
+				.getServiceInstanceBinding(pathVariables, "nonexistent-service-id", "nonexistent-binding-id", null, null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);


### PR DESCRIPTION
When service instance doesn't exist service broker throws `ServiceInstanceDoesNotExistException` and then it will be maped to `422 Unprocessable Entity` via `ServiceBrokerExceptionHandler`.
However it must return a response with code `404 Not Found`.
Fixes #223