### PR TITLE
Add `maintenance_info` field to Service Plan object

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/MaintenanceInfo.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/MaintenanceInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web;
+
+/**
+ * Internal class for marshaling {@link ServiceBrokerProperties} configuration properties
+ * that describes a maintenance info available for a {@link Plan}.
+ *
+ * @author ilyavy
+ * @see org.springframework.cloud.servicebroker.model.catalog.MaintenanceInfo
+ */
+public class MaintenanceInfo {
+
+	/**
+	 * The version of the maintenance update available for a plan.
+	 */
+	private String version;
+
+	/**
+	 * The description of the impact of the maintenance update.
+	 */
+	private String description;
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	/**
+	 * Converts this object into its corresponding model.
+	 *
+	 * @return a MaintenanceInfo model
+	 * @see org.springframework.cloud.servicebroker.model.catalog.MaintenanceInfo
+	 */
+	public org.springframework.cloud.servicebroker.model.catalog.MaintenanceInfo toModel() {
+		return org.springframework.cloud.servicebroker.model.catalog.MaintenanceInfo.builder()
+				.version(this.version)
+				.description(this.description)
+				.build();
+	}
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/Plan.java
@@ -88,6 +88,12 @@ public class Plan {
 	 */
 	private Integer maximumPollingDuration;
 
+	/**
+	 * Maintenance information for a Service Instance which is provisioned using the Service Plan. If provided,
+	 * a version string MUST be provided and platforms MAY use this when Provisioning or Updating a Service Instance.
+	 */
+	private MaintenanceInfo maintenanceInfo;
+
 	public String getId() {
 		return this.id;
 	}
@@ -160,6 +166,14 @@ public class Plan {
 		this.maximumPollingDuration = maximumPollingDuration;
 	}
 
+	public MaintenanceInfo getMaintenanceInfo() {
+		return maintenanceInfo;
+	}
+
+	public void setMaintenanceInfo(MaintenanceInfo maintenanceInfo) {
+		this.maintenanceInfo = maintenanceInfo;
+	}
+
 	/**
 	 * Converts this object into its corresponding model
 	 *
@@ -175,8 +189,9 @@ public class Plan {
 				.free(this.free)
 				.planUpdateable(this.planUpdateable)
 				.schemas(this.schemas == null ? null : this.schemas.toModel())
-				.metadata(this.metadata == null ? null: this.metadata.toModel())
+				.metadata(this.metadata == null ? null : this.metadata.toModel())
 				.maximumPollingDuration(this.maximumPollingDuration)
+				.maintenanceInfo(this.maintenanceInfo == null ? null : this.maintenanceInfo.toModel())
 				.build();
 	}
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesBindingTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesBindingTest.java
@@ -148,6 +148,8 @@ public class ServiceBrokerPropertiesBindingTest {
 		assertThat(catalog.getServices().get(0).getPlans().get(0).getId()).isEqualTo("plan-one-id");
 		assertThat(catalog.getServices().get(0).getPlans().get(0).getName()).isEqualTo("Plan One");
 		assertThat(catalog.getServices().get(0).getPlans().get(0).getDescription()).isEqualTo("Description for Plan One");
+		assertThat(catalog.getServices().get(0).getPlans().get(0).getMaintenanceInfo().getVersion()).isEqualTo("1.0.1");
+		assertThat(catalog.getServices().get(0).getPlans().get(0).getMaintenanceInfo().getDescription()).isEqualTo("Description for maintenance info");
 		assertThat(catalog.getServices().get(0).getPlans().get(1).getId()).isEqualTo("plan-two-id");
 		assertThat(catalog.getServices().get(0).getPlans().get(1).getName()).isEqualTo("Plan Two");
 		assertThat(catalog.getServices().get(0).getPlans().get(1).getDescription()).isEqualTo("Description for Plan Two");

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ServiceBrokerPropertiesTest.java
@@ -95,6 +95,8 @@ public class ServiceBrokerPropertiesTest {
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[0].id", "plan-one-id");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[0].name", "Plan One");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[0].description", "Description for Plan One");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[0].maintenance_info.version", "1.0.1");
+		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[0].maintenance_info.description", "Description for maintenance info");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].id", "plan-two-id");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].name", "Plan Two");
 		map.put("spring.cloud.openservicebroker.catalog.services[0].plans[1].description", "Description for Plan Two");
@@ -152,6 +154,8 @@ public class ServiceBrokerPropertiesTest {
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(0).getId()).isEqualTo("plan-one-id");
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(0).getName()).isEqualTo("Plan One");
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(0).getDescription()).isEqualTo("Description for Plan One");
+		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(0).getMaintenanceInfo().getVersion()).isEqualTo("1.0.1");
+		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(0).getMaintenanceInfo().getDescription()).isEqualTo("Description for maintenance info");
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getId()).isEqualTo("plan-two-id");
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getName()).isEqualTo("Plan Two");
 		assertThat(properties.getCatalog().getServices().get(0).getPlans().get(1).getDescription()).isEqualTo("Description for Plan Two");
@@ -205,6 +209,8 @@ public class ServiceBrokerPropertiesTest {
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(0).getId()).isEqualTo("plan-one-id");
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(0).getName()).isEqualTo("Plan One");
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(0).getDescription()).isEqualTo("Description for Plan One");
+		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(0).getMaintenanceInfo().getVersion().toString()).isEqualTo("1.0.1");
+		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(0).getMaintenanceInfo().getDescription()).isEqualTo("Description for maintenance info");
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getId()).isEqualTo("plan-two-id");
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getName()).isEqualTo("Plan Two");
 		assertThat(catalog.getServiceDefinitions().get(0).getPlans().get(1).getDescription()).isEqualTo("Description for Plan Two");

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/fixture/ServiceFixture.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/fixture/ServiceFixture.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.servicebroker.autoconfigure.web.fixture;
 
+import org.springframework.cloud.servicebroker.model.catalog.MaintenanceInfo;
 import org.springframework.cloud.servicebroker.model.catalog.MethodSchema;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.Schemas;
@@ -46,6 +47,10 @@ public final class ServiceFixture {
 				.id("plan-one-id")
 				.name("Plan One")
 				.description("Description for Plan One")
+				.maintenanceInfo(MaintenanceInfo.builder()
+						.version("1.0.0-alpha+001")
+						.description("Description for maintenance info")
+						.build())
 				.build();
 	}
 
@@ -85,9 +90,9 @@ public final class ServiceFixture {
 
 	private static Plan getPlanThree() {
 		return Plan.builder()
-				   .id("plan-three-id")
-				   .name("Plan Three")
-				   .description("Description for Plan Three")
-				   .build();
+				.id("plan-three-id")
+				.name("Plan Three")
+				.description("Description for Plan Three")
+				.build();
 	}
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/CatalogControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/CatalogControllerIntegrationTest.java
@@ -111,6 +111,9 @@ public class CatalogControllerIntegrationTest {
 				.jsonPath("$.services[0].plans[0].name").isEqualTo(plans.get(0).getName())
 				.jsonPath("$.services[0].plans[0].description").isEqualTo(plans.get(0).getDescription())
 				.jsonPath("$.services[0].plans[0].free").isEqualTo(plans.get(0).isFree())
+				.jsonPath("$.services[0].plans[0].maintenance_info").isNotEmpty()
+				.jsonPath("$.services[0].plans[0].maintenance_info.version").isEqualTo("1.0.0-alpha+001")
+				.jsonPath("$.services[0].plans[0].maintenance_info.description").isEqualTo("Description for maintenance info")
 				.jsonPath("$.services[0].plans[1].id").isEqualTo(plans.get(1).getId())
 				.jsonPath("$.services[0].plans[1].name").isEqualTo(plans.get(1).getName())
 				.jsonPath("$.services[0].plans[1].description").isEqualTo(plans.get(1).getDescription())
@@ -122,10 +125,12 @@ public class CatalogControllerIntegrationTest {
 				.jsonPath("$.services[0].plans[1].schemas.service_instance.update.parameters").isEqualTo(updateServiceInstanceSchema)
 				.jsonPath("$.services[0].plans[1].schemas.service_binding.create.parameters").isEqualTo(createServiceBindingSchema)
 				.jsonPath("$.services[0].plans[1].maximum_polling_duration").isEqualTo(plans.get(1).getMaximumPollingDuration())
+				.jsonPath("$.services[0].plans[1].maintenance_info").doesNotExist()
 			  	.jsonPath("$.services[0].plans[2].id").isEqualTo(plans.get(2).getId())
 			  	.jsonPath("$.services[0].plans[2].name").isEqualTo(plans.get(2).getName())
 			  	.jsonPath("$.services[0].plans[2].description").isEqualTo(plans.get(2).getDescription())
 			  	.jsonPath("$.services[0].plans[2].free").isEqualTo(plans.get(2).isFree())
+				.jsonPath("$.services[0].plans[2].maintenance_info").doesNotExist()
 			  	.jsonPath("$.services[0].plans[3]").doesNotExist()
 				.jsonPath("$.services[1]").doesNotExist();
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/CatalogControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/CatalogControllerIntegrationTest.java
@@ -137,7 +137,9 @@ public class CatalogControllerIntegrationTest {
 				.andExpect(jsonPath("$.services[*].plans[*].maximum_polling_duration", contains(plans.get(1).getMaximumPollingDuration())))
 				.andExpect(jsonPath("$.services[*].plans[*].schemas.service_instance.create.parameters", contains(createServiceInstanceSchema)))
 				.andExpect(jsonPath("$.services[*].plans[*].schemas.service_instance.update.parameters", contains(updateServiceInstanceSchema)))
-				.andExpect(jsonPath("$.services[*].plans[*].schemas.service_binding.create.parameters", contains(createServiceBindingSchema)));
+				.andExpect(jsonPath("$.services[*].plans[*].schemas.service_binding.create.parameters", contains(createServiceBindingSchema)))
+				.andExpect(jsonPath("$.services[*].plans[*].maintenance_info.version", contains(plans.get(0).getMaintenanceInfo().getVersion())))
+				.andExpect(jsonPath("$.services[*].plans[*].maintenance_info.description", contains(plans.get(0).getMaintenanceInfo().getDescription())));
 	}
 
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.properties
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.properties
@@ -23,6 +23,8 @@ spring.cloud.openservicebroker.catalog.services[0].dashboard-client.redirect-uri
 spring.cloud.openservicebroker.catalog.services[0].plans[0].id=plan-one-id
 spring.cloud.openservicebroker.catalog.services[0].plans[0].name=Plan One
 spring.cloud.openservicebroker.catalog.services[0].plans[0].description=Description for Plan One
+spring.cloud.openservicebroker.catalog.services[0].plans[0].maintenance_info.version=1.0.1
+spring.cloud.openservicebroker.catalog.services[0].plans[0].maintenance_info.description=Description for maintenance info
 spring.cloud.openservicebroker.catalog.services[0].plans[1].id=plan-two-id
 spring.cloud.openservicebroker.catalog.services[0].plans[1].name=Plan Two
 spring.cloud.openservicebroker.catalog.services[0].plans[1].description=Description for Plan Two

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.yml
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.yml
@@ -34,6 +34,9 @@ spring:
           - description: Description for Plan One
             id: plan-one-id
             name: Plan One
+            maintenance_info:
+              version: 1.0.1
+              description: "Description for maintenance info"
           - description: Description for Plan Two
             id: plan-two-id
             name: Plan Two

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/MaintenanceInfo.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/MaintenanceInfo.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.model.catalog;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Maintenance info available for a Plan.
+ *
+ * @author ilyavy
+ * @see <a href=
+ * "https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#maintenance-info-object">Open
+ * Service Broker API specification</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MaintenanceInfo {
+
+	private static final Pattern SEMANTIC_VERSION_V2_PATTERN = Pattern.compile("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|" +
+			"[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?" +
+			"(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$");
+
+	@NotNull
+	private final String version;
+
+	private final String description;
+
+	/**
+	 * Constructs a new {@link MaintenanceInfo}
+	 *
+	 * @param version     maintenance version (conforming to a semantic version 2.0)
+	 * @param description description of the impact of the maintenance update
+	 * @throws IllegalArgumentException if the provided to the builder version does not comply to semantic
+	 *                                  versioning v2 specification
+	 */
+	public MaintenanceInfo(String version, String description) {
+		if (!SEMANTIC_VERSION_V2_PATTERN.matcher(version).matches()) {
+			throw new IllegalArgumentException(
+					"Version provided should comply to semantic version v2 specification");
+		}
+		this.version = version;
+		this.description = description;
+	}
+
+	/**
+	 * The version of the maintenance update available for a plan.
+	 *
+	 * @return the version
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * The description of the impact of the maintenance update.
+	 *
+	 * @return the description
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * Creates a builder that provides a fluent API for constructing a {@literal MaintenanceInfo}.
+	 *
+	 * @return the builder
+	 */
+	public static MaintenanceInfoBuilder builder() {
+		return new MaintenanceInfoBuilder();
+	}
+
+	@Override
+	public final boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		MaintenanceInfo that = (MaintenanceInfo) o;
+		return Objects.equals(version, that.version) &&
+				Objects.equals(description, that.description);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(version, description);
+	}
+
+	@Override
+	public String toString() {
+		return "MaintenanceInfo{" +
+				"version='" + version +
+				", description='" + description +
+				'}';
+	}
+
+	/**
+	 * Provides a fluent API for constructing a {@literal MaintenanceInfo}.
+	 */
+	public static class MaintenanceInfoBuilder {
+		private String version;
+
+		private String description;
+
+		private MaintenanceInfoBuilder() {
+		}
+
+		/**
+		 * The version of the maintenance update available for a plan.
+		 *
+		 * @param version the version
+		 * @return the builder instance
+		 */
+		public MaintenanceInfoBuilder version(String version) {
+			this.version = version;
+			return this;
+		}
+
+		/**
+		 * The version of the maintenance update available for a plan.
+		 *
+		 * @param major     MAJOR version when you make incompatible API changes
+		 * @param minor     MINOR version when you add functionality in a backwards-compatible manner
+		 * @param patch     PATCH version when you make backwards-compatible bug fixes
+		 * @param extension additional labels for pre-release and build metadata
+		 * @return the builder instance
+		 */
+		public MaintenanceInfoBuilder version(int major, int minor, int patch, String extension) {
+			return this.version(major + "." + minor + "." + patch + extension);
+		}
+
+		/**
+		 * The description of the impact of the maintenance update.
+		 *
+		 * @param description the description
+		 * @return the builder instance
+		 */
+		public MaintenanceInfoBuilder description(String description) {
+			this.description = description;
+			return this;
+		}
+
+		/**
+		 * Constructs a {@link MaintenanceInfo} from the provided values.
+		 *
+		 * @return the newly constructed {@literal MaintenanceInfo}
+		 * @throws IllegalArgumentException if the provided to the builder version does not comply to semantic
+		 *                                  versioning v2 specification
+		 */
+		public MaintenanceInfo build() {
+			return new MaintenanceInfo(version, description);
+		}
+	}
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Plan.java
@@ -64,12 +64,14 @@ public class Plan {
 
 	private final Integer maximumPollingDuration;
 
+	private final MaintenanceInfo maintenanceInfo;
+
 
 	/**
 	 * Construct a new {@link Plan}
 	 */
 	public Plan() {
-		this(null, null, null, new HashMap<>(), null, null, null, null, null);
+		this(null, null, null, new HashMap<>(), null, null, null, null, null, null);
 	}
 
 	/**
@@ -86,7 +88,8 @@ public class Plan {
 	 * @param maximumPollingDuration the maximum polling duration in seconds
 	 */
 	public Plan(String id, String name, String description, Map<String, Object> metadata, Boolean free,
-				Boolean bindable, Boolean planUpdateable, Schemas schemas, Integer maximumPollingDuration) {
+				Boolean bindable, Boolean planUpdateable, Schemas schemas, Integer maximumPollingDuration,
+				MaintenanceInfo maintenanceInfo) {
 		this.id = id;
 		this.name = name;
 		this.description = description;
@@ -96,6 +99,7 @@ public class Plan {
 		this.planUpdateable = planUpdateable;
 		this.schemas = schemas;
 		this.maximumPollingDuration = maximumPollingDuration;
+		this.maintenanceInfo = maintenanceInfo;
 	}
 
 	/**
@@ -193,6 +197,16 @@ public class Plan {
 	}
 
 	/**
+	 * Maintenance information for a Service Instance which is provisioned using the Service Plan. If provided,
+	 * a version string MUST be provided and platforms MAY use this when Provisioning or Updating a Service Instance.
+	 *
+	 * @return the maintenance info
+	 */
+	public MaintenanceInfo getMaintenanceInfo() {
+		return maintenanceInfo;
+	}
+
+	/**
 	 * Create a builder that provides a fluent API for constructing a {@literal Plan}.
 	 *
 	 * @return the builder
@@ -218,12 +232,14 @@ public class Plan {
 				Objects.equals(bindable, plan.bindable) &&
 				Objects.equals(planUpdateable, plan.planUpdateable) &&
 				Objects.equals(schemas, plan.schemas) &&
-				Objects.equals(maximumPollingDuration, plan.maximumPollingDuration);
+				Objects.equals(maximumPollingDuration, plan.maximumPollingDuration) &&
+				Objects.equals(maintenanceInfo, plan.maintenanceInfo);
 	}
 
 	@Override
 	public final int hashCode() {
-		return Objects.hash(id, name, description, metadata, free, bindable, planUpdateable, schemas, maximumPollingDuration);
+		return Objects.hash(id, name, description, metadata, free, bindable,
+				planUpdateable, schemas, maximumPollingDuration, maintenanceInfo);
 	}
 
 	@Override
@@ -238,6 +254,7 @@ public class Plan {
 				", planUpdateable=" + planUpdateable +
 				", schemas=" + schemas +
 				", maximumPollingDuration=" + maximumPollingDuration +
+				", maintenanceInfo=" + maintenanceInfo +
 				'}';
 	}
 
@@ -254,6 +271,7 @@ public class Plan {
 		private Boolean planUpdateable;
 		private Schemas schemas;
 		private Integer maximumPollingDuration;
+		private MaintenanceInfo maintenanceInfo;
 
 		private PlanBuilder() {
 		}
@@ -394,12 +412,25 @@ public class Plan {
 		}
 
 		/**
+		 * Maintenance information for a Service Instance which is provisioned using the Service Plan. If provided a
+		 * version string MUST be provided and platforms MAY use this when Provisioning or Updating a Service Instance.
+		 *
+		 * @param maintenanceInfo the maintenanceInfo
+		 * @return the builder instance
+		 */
+		public PlanBuilder maintenanceInfo(MaintenanceInfo maintenanceInfo) {
+			this.maintenanceInfo = maintenanceInfo;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link Plan} from the provided values.
 		 *
 		 * @return the newly constructed {@literal Plan}
 		 */
 		public Plan build() {
-			return new Plan(id, name, description, metadata, free, bindable, planUpdateable, schemas, maximumPollingDuration);
+			return new Plan(id, name, description, metadata, free, bindable,
+					planUpdateable, schemas, maximumPollingDuration, maintenanceInfo);
 		}
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/MaintenanceInfoTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/MaintenanceInfoTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.model.catalog;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MaintenanceInfoTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void incorrectVersion() {
+		constructInfoAndValidate("157.2", "description");
+	}
+
+	@Test
+	public void simpleVersion() {
+		constructInfoAndValidate("1.1.1", "description");
+	}
+
+	@Test
+	public void simpleVersionDescriptionIsNull() {
+		constructInfoAndValidate("1.1.1", null);
+	}
+
+	@Test
+	public void versionWithExtension() {
+		constructInfoAndValidate("1.0.0-beta+exp.sha.5114f85", "description");
+	}
+
+	@Test
+	public void simpleVersionCompoundVersionConstructor() {
+		constructInfoAndValidate(1, 1, 1, "", "description");
+	}
+
+	@Test
+	public void versionWithExtensionCompoundVersionConstructor() {
+		constructInfoAndValidate(1, 0, 0, "-beta+exp.sha.5114f85", "description");
+	}
+
+	private void constructInfoAndValidate(String version, String description) {
+		MaintenanceInfo info = MaintenanceInfo.builder()
+				.version(version)
+				.description(description)
+				.build();
+		assertThat(info.getVersion()).isEqualTo(version);
+		assertThat(info.getDescription()).isEqualTo(description);
+	}
+
+	private void constructInfoAndValidate(int major, int minor, int patch, String extension, String description) {
+		final String version = major + "." + minor + "." + patch + extension;
+
+		MaintenanceInfo info = MaintenanceInfo.builder()
+				.version(major, minor, patch, extension)
+				.description(description)
+				.build();
+		assertThat(info.getVersion()).isEqualTo(version);
+		assertThat(info.getDescription()).isEqualTo(description);
+	}
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/PlanTest.java
@@ -110,6 +110,10 @@ public class PlanTest {
 				.metadata(metadata)
 				.schemas(Schemas.builder().build())
 				.maximumPollingDuration(210)
+				.maintenanceInfo(MaintenanceInfo.builder()
+						.version(1, 0, 0, "-alpha+001")
+						.description("Description for maintenance info")
+						.build())
 				.build();
 
 		assertThat(plan.getId()).isEqualTo("plan-id-one");
@@ -117,6 +121,7 @@ public class PlanTest {
 		assertThat(plan.getDescription()).isEqualTo("Plan One");
 		assertThat(plan.isFree()).isEqualTo(false);
 		assertThat(plan.isBindable()).isEqualTo(true);
+		assertThat(plan.isPlanUpdateable()).isEqualTo(true);
 		assertThat(plan.getMetadata()).hasSize(7);
 		assertThat(plan.getMetadata()).contains(
 				entry("field1", "value1"),
@@ -128,6 +133,9 @@ public class PlanTest {
 				entry("costs", costs)
 		);
 		assertThat(plan.getSchemas()).isNotNull();
+		assertThat(plan.getMaximumPollingDuration()).isEqualTo(210);
+		assertThat(plan.getMaintenanceInfo().getVersion()).isEqualTo("1.0.0-alpha+001");
+		assertThat(plan.getMaintenanceInfo().getDescription()).isEqualTo("Description for maintenance info");
 
 		DocumentContext json = JsonUtils.toJsonPath(plan);
 
@@ -151,6 +159,8 @@ public class PlanTest {
 		assertThat(json).hasListAtPath("$.metadata.bullets").containsOnly("bullet1", "bullet2");
 		assertThat(json).hasPath("$.schemas");
 		assertThat(json).hasPath("$.maximum_polling_duration").isEqualTo(210);
+		assertThat(json).hasPath("$.maintenance_info.version").isEqualTo("1.0.0-alpha+001");
+		assertThat(json).hasPath("$.maintenance_info.description").isEqualTo("Description for maintenance info");
 	}
 
 	@Test


### PR DESCRIPTION
Resolves #233

OSB 2.15 adds a maintenance_info field to the Service Plan. Service Brokers can specify optional Maintenance information for a Service Instance which is provisioned using the Service Plan. 

If the value is null, the field will be omitted from the serialized JSON.

I used [Java implementation of the Semantic Versioning Specification](https://github.com/zafarkhaja/jsemver) to make sure that provided version complies to [semantic version 2.0](https://semver.org/spec/v2.0.0.html), as [it described by the specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#maintenance-info-object).
