### PR TITLE
Restrict Operation strings to 10,000 characters in the response body

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Details of a response that support asynchronous behavior.
  *
@@ -29,6 +31,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AsyncServiceBrokerResponse {
+
+	private static final int MAX_OPERATION_LENGTH = 10_000;
 
 	@JsonIgnore //not sent on the wire as json payload, but as http status instead
 	protected final boolean async;
@@ -40,8 +44,13 @@ public class AsyncServiceBrokerResponse {
 	 * Create a new AsyncServiceBrokerResponse
 	 * @param async is the operation asynchronous
 	 * @param operation description of the operation being performed
+	 * @throws IllegalArgumentException if operation length exceeds 10,000 characters
 	 */
 	protected AsyncServiceBrokerResponse(boolean async, String operation) {
+		if (StringUtils.hasLength(operation) && operation.length() > MAX_OPERATION_LENGTH) {
+			throw new IllegalArgumentException("operation strings are restricted to 10,000 characters in the response" +
+					" body");
+		}
 		this.async = async;
 		this.operation = operation;
 	}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceAppBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceAppBindingResponseTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.jayway.jsonpath.DocumentContext;
+import net.bytebuddy.utility.RandomString;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
@@ -128,5 +129,26 @@ public class CreateServiceInstanceAppBindingResponseTest {
 				.forClass(CreateServiceInstanceAppBindingResponse.class)
 				.withRedefinedSuperclass()
 				.verify();
+	}
+
+	@Test
+	public void withinOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceAppBindingResponse.builder()
+				.operation(RandomString.make(9_999))
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void exceedsOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceAppBindingResponse.builder()
+				.operation(RandomString.make(10_001))
+				.build();
+	}
+
+	@Test
+	public void exactlyOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceAppBindingResponse.builder()
+				.operation(RandomString.make(10_000))
+				.build();
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceRouteBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceRouteBindingResponseTest.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.servicebroker.model.binding;
 
 import com.jayway.jsonpath.DocumentContext;
+import net.bytebuddy.utility.RandomString;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
@@ -70,5 +71,26 @@ public class CreateServiceInstanceRouteBindingResponseTest {
 				.forClass(CreateServiceInstanceRouteBindingResponse.class)
 				.withRedefinedSuperclass()
 				.verify();
+	}
+
+	@Test
+	public void withinOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceRouteBindingResponse.builder()
+				.operation(RandomString.make(9_999))
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void exceedsOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceRouteBindingResponse.builder()
+				.operation(RandomString.make(10_001))
+				.build();
+	}
+
+	@Test
+	public void exactlyOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceRouteBindingResponse.builder()
+				.operation(RandomString.make(10_000))
+				.build();
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingResponseTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.servicebroker.model.binding;
 
+import net.bytebuddy.utility.RandomString;
 import org.junit.Test;
 
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -49,5 +50,26 @@ public class DeleteServiceInstanceBindingResponseTest {
 				"deleteResponse.json", DeleteServiceInstanceBindingResponse.class);
 
 		assertThat(response.getOperation()).isEqualTo("in progress");
+	}
+
+	@Test
+	public void withinOperationCharacterLimit() throws Exception {
+		DeleteServiceInstanceBindingResponse.builder()
+				.operation(RandomString.make(9_999))
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void exceedsOperationCharacterLimit() throws Exception {
+		DeleteServiceInstanceBindingResponse.builder()
+				.operation(RandomString.make(10_001))
+				.build();
+	}
+
+	@Test
+	public void exactlyOperationCharacterLimit() throws Exception {
+		DeleteServiceInstanceBindingResponse.builder()
+				.operation(RandomString.make(10_000))
+				.build();
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponseTest.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.servicebroker.model.instance;
 
 import com.jayway.jsonpath.DocumentContext;
+import net.bytebuddy.utility.RandomString;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
@@ -78,5 +79,26 @@ public class CreateServiceInstanceResponseTest {
 				.forClass(CreateServiceInstanceResponse.class)
 				.withRedefinedSuperclass()
 				.verify();
+	}
+
+	@Test
+	public void withinOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceResponse.builder()
+				.operation(RandomString.make(9_999))
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void exceedsOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceResponse.builder()
+				.operation(RandomString.make(10_001))
+				.build();
+	}
+
+	@Test
+	public void exactlyOperationCharacterLimit() throws Exception {
+		CreateServiceInstanceResponse.builder()
+				.operation(RandomString.make(10_000))
+				.build();
 	}
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceResponseTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.servicebroker.model.instance;
 
+import net.bytebuddy.utility.RandomString;
 import org.junit.Test;
 
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -23,6 +24,7 @@ import org.springframework.cloud.servicebroker.JsonUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DeleteServiceInstanceResponseTest {
+
 	@Test
 	public void responseWithDefaultsIsBuilt() {
 		DeleteServiceInstanceResponse response = DeleteServiceInstanceResponse.builder()
@@ -49,5 +51,26 @@ public class DeleteServiceInstanceResponseTest {
 				"deleteResponse.json", DeleteServiceInstanceResponse.class);
 
 		assertThat(response.getOperation()).isEqualTo("in progress");
+	}
+
+	@Test
+	public void withinOperationCharacterLimit() throws Exception {
+		DeleteServiceInstanceResponse.builder()
+				.operation(RandomString.make(9_999))
+				.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void exceedsOperationCharacterLimit() throws Exception {
+		DeleteServiceInstanceResponse.builder()
+				.operation(RandomString.make(10_001))
+				.build();
+	}
+
+	@Test
+	public void exactlyOperationCharacterLimit() throws Exception {
+		DeleteServiceInstanceResponse.builder()
+				.operation(RandomString.make(10_000))
+				.build();
 	}
 }


### PR DESCRIPTION
Applies to the following response:
- CreateServiceInstanceResponse
- DeleteServiceInstanceResponse
- CreateServiceInstanceAppBindingResponse
- CreateServiceInstanceRouteBindingResponse
- DeleteServiceInstanceBindingResponse

Resolves #231