### PR TITLE
Support `X-Broker-API-Request-Identity` request identity header

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/RequestIdentityWebFilter.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/RequestIdentityWebFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+/**
+ * {@link WebFilter} that inspects the request for the presence of the {@literal X-Broker-API-Request-Identity} header
+ * and sets the corresponding value in the same response header
+ *
+ * @author Roy Clarkson
+ */
+public class RequestIdentityWebFilter implements WebFilter {
+
+	/**
+	 * Sets the {@literal X-Broker-API-Request-Identity} header in the response if a value is received in the request
+	 * from the platform
+	 *
+	 * @param exchange {@inheritDoc}
+	 * @param chain {@inheritDoc}
+	 * @return {@inheritDoc}
+	 */
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+		String requestIdentity = exchange.getRequest().getHeaders()
+				.getFirst(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER);
+		if (StringUtils.hasLength(requestIdentity)) {
+			exchange.getResponse().getHeaders().add(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, requestIdentity);
+		}
+		return chain.filter(exchange);
+	}
+
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceBrokerWebFluxAutoConfiguration.java
@@ -118,4 +118,14 @@ public class ServiceBrokerWebFluxAutoConfiguration {
 		return new ServiceBrokerWebFluxExceptionHandler();
 	}
 
+	/**
+	 * Provide a {@link RequestIdentityWebFilter} bean
+	 *
+	 * @return the bean
+	 */
+	@Bean
+	public RequestIdentityWebFilter requestIdentityWebFilter() {
+		return new RequestIdentityWebFilter();
+	}
+
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptor.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+/**
+ * {@link HandlerInterceptor} that inspects the request for the presence of the {@literal X-Broker-API-Request
+ * -Identity} header and sets the corresponding value in the same response header
+ *
+ * @author Roy Clarkson
+ */
+public class RequestIdentityInterceptor extends HandlerInterceptorAdapter {
+
+	/**
+	 * Sets the {@literal X-Broker-API-Request-Identity} header in the response if a value is received in the request
+	 * from the platform
+	 *
+	 * @param request {@inheritDoc}
+	 * @param response {@inheritDoc}
+	 * @param handler {@inheritDoc}
+	 */
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		String requestIdentity = request.getHeader(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER);
+		if (StringUtils.hasLength(requestIdentity)) {
+			response.addHeader(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, requestIdentity);
+		}
+		return true;
+	}
+
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/main/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceBrokerWebMvcAutoConfiguration.java
@@ -119,4 +119,14 @@ public class ServiceBrokerWebMvcAutoConfiguration {
 		return new ServiceBrokerWebMvcExceptionHandler();
 	}
 
+	/**
+	 * Provide a {@link RequestIdentityInterceptor} bean
+	 *
+	 * @return the bean
+	 */
+	@Bean
+	public RequestIdentityInterceptor requestIdentityInterceptor() {
+		return new RequestIdentityInterceptor();
+	}
+
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/RequestIdentityWebFilterIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/RequestIdentityWebFilterIntegrationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.cloud.servicebroker.controller.CatalogController;
+import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
+import org.springframework.cloud.servicebroker.service.CatalogService;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestIdentityWebFilterIntegrationTest {
+
+	private static final String CATALOG_PATH = "/v2/catalog";
+
+	@InjectMocks
+	private CatalogController controller;
+
+	@Mock
+	@SuppressWarnings("unused")
+	private CatalogService catalogService;
+
+	private WebTestClient client;
+
+	@BeforeEach
+	public void setUp() {
+		this.client = WebTestClient.bindToController(controller)
+				.webFilter(new RequestIdentityWebFilter())
+				.build();
+	}
+
+	@Test
+	public void noHeaderSent() throws Exception {
+		client.get().uri(CATALOG_PATH)
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectBody()
+				.consumeWith(result -> assertThat(
+						result.getResponseHeaders().getFirst(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER))
+						.isNull());
+	}
+
+	@Test
+	public void headerSent() throws Exception {
+		client.get().uri(CATALOG_PATH)
+				.header(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, "request-id")
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectBody()
+				.consumeWith(result -> assertThat(
+						result.getResponseHeaders().getFirst(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER))
+						.isEqualTo("request-id"));
+	}
+
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/RequestIdentityWebFilterTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/RequestIdentityWebFilterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web.reactive;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+public class RequestIdentityWebFilterTest {
+
+	private static final String V2_API_PATH_PATTERN = "/v2/**";
+
+	private MockServerWebExchange exchange;
+
+	@Mock
+	private WebFilterChain chain;
+
+	@Test
+	public void requestIdentityHeader() {
+		MockServerHttpRequest request = MockServerHttpRequest
+				.get(V2_API_PATH_PATTERN)
+				.header(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, "request-id")
+				.build();
+		this.exchange = MockServerWebExchange.from(request);
+		MockitoAnnotations.initMocks(this);
+		given(chain.filter(exchange)).willReturn(Mono.empty());
+		RequestIdentityWebFilter webFilter = new RequestIdentityWebFilter();
+		webFilter.filter(exchange, chain).block();
+		assertThat(exchange.getResponse().getHeaders().getFirst(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER))
+				.isEqualTo("request-id");
+	}
+
+	@Test
+	public void requestIdentityHeaderMissing() {
+		MockServerHttpRequest request = MockServerHttpRequest
+				.get(V2_API_PATH_PATTERN)
+				.build();
+		this.exchange = MockServerWebExchange.from(request);
+		MockitoAnnotations.initMocks(this);
+		given(chain.filter(exchange)).willReturn(Mono.empty());
+		RequestIdentityWebFilter webFilter = new RequestIdentityWebFilter();
+		webFilter.filter(exchange, chain).block();
+		assertThat(exchange.getResponse().getHeaders().getFirst(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER)).isNull();
+	}
+
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptorIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptorIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.servicebroker.controller.CatalogController;
+import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.service.CatalogService;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestIdentityInterceptorIntegrationTest {
+
+	private final static String CATALOG_PATH = "/v2/catalog";
+
+	@InjectMocks
+	private CatalogController controller;
+
+	@Mock
+	@SuppressWarnings("unused")
+	private CatalogService catalogService;
+
+	private MockMvc mvc;
+
+	@BeforeEach
+	public void setUp() {
+		this.mvc = MockMvcBuilders.standaloneSetup(controller)
+				.addInterceptors(new RequestIdentityInterceptor())
+				.build();
+		given(catalogService.getCatalog())
+				.willReturn(Mono.just(Catalog.builder().build()));
+	}
+
+	@Test
+	public void noHeaderSent() throws Exception {
+		mvc.perform(get(CATALOG_PATH)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(result -> assertThat(
+						result.getResponse().getHeaderValue(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER)).isNull())
+				.andReturn();
+	}
+
+	@Test
+	public void headerSent() throws Exception {
+		mvc.perform(get(CATALOG_PATH)
+				.header(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, "request-id")
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(result -> assertThat(
+						result.getResponse().getHeaderValue(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER))
+						.isEqualTo("request-id"))
+				.andReturn();
+	}
+
+}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptorTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.autoconfigure.web.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class RequestIdentityInterceptorTest {
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@BeforeEach
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void defaultBehaviorReturnsTrue() {
+		RequestIdentityInterceptor interceptor = new RequestIdentityInterceptor();
+		assertThat(interceptor.preHandle(request, response, null)).isTrue();
+	}
+
+	@Test
+	public void requestIdentityHeader() {
+		given(request.getHeader(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER)).willReturn("request-id");
+		RequestIdentityInterceptor interceptor = new RequestIdentityInterceptor();
+		assertThat(interceptor.preHandle(request, response, null)).isTrue();
+		verify(response, times(1)).addHeader(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER,
+				"request-id");
+	}
+
+	@Test
+	public void requestIdentityHeaderIsMissing() {
+		given(request.getHeader(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER)).willReturn(null);
+		RequestIdentityInterceptor interceptor = new RequestIdentityInterceptor();
+		assertThat(interceptor.preHandle(request, response, null)).isTrue();
+		assertThat(response.getHeader(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER)).isNull();
+	}
+
+}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/BaseController.java
@@ -70,13 +70,15 @@ public class BaseController {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentityString identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 * @return the request with the applied headers
 	 */
 	protected Mono<ServiceBrokerRequest> configureCommonRequestFields(ServiceBrokerRequest request, String platformInstanceId,
-			String apiInfoLocation, String originatingIdentityString) {
+			String apiInfoLocation, String originatingIdentityString, String requestIdentity) {
 		request.setPlatformInstanceId(platformInstanceId);
 		request.setApiInfoLocation(apiInfoLocation);
 		request.setOriginatingIdentity(parseOriginatingIdentity(originatingIdentityString));
+		request.setRequestIdentity(requestIdentity);
 		return Mono.just(request);
 	}
 
@@ -87,13 +89,15 @@ public class BaseController {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentityString identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 * @param asyncAccepted does the platform accept asynchronous requests
 	 * @return the request with the applied headers
 	 */
 	protected Mono<AsyncServiceBrokerRequest> configureCommonRequestFields(AsyncServiceBrokerRequest request, String platformInstanceId,
-			String apiInfoLocation, String originatingIdentityString, boolean asyncAccepted) {
+			String apiInfoLocation, String originatingIdentityString, String requestIdentity, boolean asyncAccepted) {
 		request.setAsyncAccepted(asyncAccepted);
-		return configureCommonRequestFields(request, platformInstanceId, apiInfoLocation, originatingIdentityString)
+		return configureCommonRequestFields(request, platformInstanceId, apiInfoLocation, originatingIdentityString,
+				requestIdentity)
 				.cast(AsyncServiceBrokerRequest.class);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -92,6 +92,7 @@ public class ServiceInstanceBindingController extends BaseController {
 	 * @param acceptsIncomplete indicates an asynchronous request
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentityString identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 * @param request the request body
 	 * @return the response
 	 */
@@ -103,6 +104,7 @@ public class ServiceInstanceBindingController extends BaseController {
 			@RequestParam(value = AsyncServiceBrokerRequest.ASYNC_REQUEST_PARAMETER, required = false) boolean acceptsIncomplete,
 			@RequestHeader(value = ServiceBrokerRequest.API_INFO_LOCATION_HEADER, required = false) String apiInfoLocation,
 			@RequestHeader(value = ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER, required = false) String originatingIdentityString,
+			@RequestHeader(value = ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, required = false) String requestIdentity,
 			@Valid @RequestBody CreateServiceInstanceBindingRequest request) {
 		return getRequiredServiceDefinition(request.getServiceDefinitionId())
 				.flatMap(serviceDefinition -> getRequiredServiceDefinitionPlan(serviceDefinition, request.getPlanId())
@@ -119,7 +121,7 @@ public class ServiceInstanceBindingController extends BaseController {
 				.cast(AsyncServiceBrokerRequest.class)
 				.flatMap(req -> configureCommonRequestFields(req,
 						pathVariables.get(ServiceBrokerRequest.PLATFORM_INSTANCE_ID_VARIABLE),
-						apiInfoLocation, originatingIdentityString, acceptsIncomplete))
+						apiInfoLocation, originatingIdentityString, requestIdentity, acceptsIncomplete))
 				.cast(CreateServiceInstanceBindingRequest.class)
 				.flatMap(req -> service.createServiceInstanceBinding(req)
 						.doOnRequest(v -> LOG.debug("Creating a service instance binding: request={}", req))
@@ -151,6 +153,7 @@ public class ServiceInstanceBindingController extends BaseController {
 	 * @param bindingId the service binding ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentityString identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 * @return the response
 	 */
 	@GetMapping({PLATFORM_PATH_MAPPING, PATH_MAPPING})
@@ -159,13 +162,15 @@ public class ServiceInstanceBindingController extends BaseController {
 			@PathVariable(ServiceBrokerRequest.INSTANCE_ID_PATH_VARIABLE) String serviceInstanceId,
 			@PathVariable(ServiceBrokerRequest.BINDING_ID_PATH_VARIABLE) String bindingId,
 			@RequestHeader(value = ServiceBrokerRequest.API_INFO_LOCATION_HEADER, required = false) String apiInfoLocation,
-			@RequestHeader(value = ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER, required = false) String originatingIdentityString) {
+			@RequestHeader(value = ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER, required = false) String originatingIdentityString,
+			@RequestHeader(value = ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, required = false) String requestIdentity) {
 		return Mono.just(GetServiceInstanceBindingRequest.builder()
 				.serviceInstanceId(serviceInstanceId)
 				.bindingId(bindingId)
 				.platformInstanceId(pathVariables.get(ServiceBrokerRequest.PLATFORM_INSTANCE_ID_VARIABLE))
 				.apiInfoLocation(apiInfoLocation)
 				.originatingIdentity(parseOriginatingIdentity(originatingIdentityString))
+				.requestIdentity(requestIdentity)
 				.build())
 				.flatMap(req -> service.getServiceInstanceBinding(req)
 						.doOnRequest(v -> LOG.debug("Getting a service instance binding: request={}", req))
@@ -195,6 +200,7 @@ public class ServiceInstanceBindingController extends BaseController {
 	 * @param operation description of the operation being performed
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentityString identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 * @return the response
 	 */
 	@GetMapping({PLATFORM_PATH_MAPPING + "/last_operation", PATH_MAPPING + "/last_operation"})
@@ -206,7 +212,8 @@ public class ServiceInstanceBindingController extends BaseController {
 			@RequestParam(value = ServiceBrokerRequest.PLAN_ID_PARAMETER, required = false) String planId,
 			@RequestParam(value = "operation", required = false) String operation,
 			@RequestHeader(value = ServiceBrokerRequest.API_INFO_LOCATION_HEADER, required = false) String apiInfoLocation,
-			@RequestHeader(value = ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER, required = false) String originatingIdentityString) {
+			@RequestHeader(value = ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER, required = false) String originatingIdentityString,
+			@RequestHeader(value = ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, required = false) String requestIdentity) {
 		return Mono.just(GetLastServiceBindingOperationRequest.builder()
 				.serviceDefinitionId(serviceDefinitionId)
 				.serviceInstanceId(serviceInstanceId)
@@ -216,6 +223,7 @@ public class ServiceInstanceBindingController extends BaseController {
 				.platformInstanceId(pathVariables.get(ServiceBrokerRequest.PLATFORM_INSTANCE_ID_VARIABLE))
 				.apiInfoLocation(apiInfoLocation)
 				.originatingIdentity(parseOriginatingIdentity(originatingIdentityString))
+				.requestIdentity(requestIdentity)
 				.build())
 				.flatMap(request -> service.getLastOperation(request)
 						.doOnRequest(
@@ -242,6 +250,7 @@ public class ServiceInstanceBindingController extends BaseController {
 	 * @param acceptsIncomplete indicates an asynchronous request
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentityString identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 * @return the response
 	 */
 	@DeleteMapping({PLATFORM_PATH_MAPPING, PATH_MAPPING})
@@ -253,7 +262,8 @@ public class ServiceInstanceBindingController extends BaseController {
 			@RequestParam(ServiceBrokerRequest.PLAN_ID_PARAMETER) String planId,
 			@RequestParam(value = AsyncServiceBrokerRequest.ASYNC_REQUEST_PARAMETER, required = false) boolean acceptsIncomplete,
 			@RequestHeader(value = ServiceBrokerRequest.API_INFO_LOCATION_HEADER, required = false) String apiInfoLocation,
-			@RequestHeader(value = ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER, required = false) String originatingIdentityString) {
+			@RequestHeader(value = ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER, required = false) String originatingIdentityString,
+			@RequestHeader(value = ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, required = false) String requestIdentity) {
 		return getRequiredServiceDefinition(serviceDefinitionId)
 				.switchIfEmpty(Mono.just(ServiceDefinition.builder().build()))
 				.flatMap(serviceDefinition -> getRequiredServiceDefinitionPlan(serviceDefinition, planId)
@@ -270,6 +280,7 @@ public class ServiceInstanceBindingController extends BaseController {
 										pathVariables.get(ServiceBrokerRequest.PLATFORM_INSTANCE_ID_VARIABLE))
 								.apiInfoLocation(apiInfoLocation)
 								.originatingIdentity(parseOriginatingIdentity(originatingIdentityString))
+								.requestIdentity(requestIdentity)
 								.build()))
 				.flatMap(req -> service.deleteServiceInstanceBinding(req)
 						.doOnRequest(v -> LOG.debug("Deleting a service instance binding: request={}", req))

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
@@ -50,10 +50,11 @@ public abstract class AsyncServiceBrokerRequest extends ServiceBrokerRequest {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	protected AsyncServiceBrokerRequest(boolean asyncAccepted, String platformInstanceId,
-			String apiInfoLocation, Context originatingIdentity) {
-		super(platformInstanceId, apiInfoLocation, originatingIdentity);
+			String apiInfoLocation, Context originatingIdentity, String requestIdentity) {
+		super(platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.asyncAccepted = asyncAccepted;
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
  * Details common to all service broker requests.
  *
  * @author Scott Frederick
+ * @author Roy Clarkson
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ServiceBrokerRequest {
@@ -39,6 +40,11 @@ public class ServiceBrokerRequest {
 	 * API Originating Identity header
 	 */
 	public final static String ORIGINATING_IDENTITY_HEADER = "X-Broker-API-Originating-Identity";
+
+	/**
+	 * API Request Identity header
+	 */
+	public final static String REQUEST_IDENTITY_HEADER = "X-Broker-API-Request-Identity";
 
 	/**
 	 * Instance ID path variable name
@@ -74,6 +80,9 @@ public class ServiceBrokerRequest {
 	@JsonIgnore //mapped as X-Broker-API-Originating-Identity Header
 	protected transient Context originatingIdentity;
 
+	@JsonIgnore //mapped as X-Broker-API-Request-Identity Header
+	protected transient String requestIdentity;
+
 	/**
 	 * Construct a new {@link ServiceBrokerRequest}
 	 */
@@ -87,11 +96,14 @@ public class ServiceBrokerRequest {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request being sent from the platform
 	 */
-	protected ServiceBrokerRequest(String platformInstanceId, String apiInfoLocation, Context originatingIdentity) {
+	protected ServiceBrokerRequest(String platformInstanceId, String apiInfoLocation, Context originatingIdentity,
+			String requestIdentity) {
 		this.platformInstanceId = platformInstanceId;
 		this.apiInfoLocation = apiInfoLocation;
 		this.originatingIdentity = originatingIdentity;
+		this.requestIdentity = requestIdentity;
 	}
 
 	/**
@@ -163,6 +175,26 @@ public class ServiceBrokerRequest {
 		this.originatingIdentity = originatingIdentity;
 	}
 
+	/**
+	 * Get the identify of the request that was sent from the platform
+	 * <p>
+	 * This value is set from the {@literal X-Broker-API-Request-Identity} header in the request from the platform
+	 *
+	 * @return the request identity, or {@literal null} if not provided
+	 */
+	public String getRequestIdentity() {
+		return this.requestIdentity;
+	}
+
+	/**
+	 * For internal use only; use a {@literal builder} to construct an object of this type and set all field values.
+	 *
+	 * @param requestIdentity identify of the request sent from the platform
+	 */
+	public void setRequestIdentity(String requestIdentity) {
+		this.requestIdentity = requestIdentity;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -175,7 +207,8 @@ public class ServiceBrokerRequest {
 		return that.canEqual(this) &&
 				Objects.equals(platformInstanceId, that.platformInstanceId) &&
 				Objects.equals(apiInfoLocation, that.apiInfoLocation) &&
-				Objects.equals(originatingIdentity, that.originatingIdentity);
+				Objects.equals(originatingIdentity, that.originatingIdentity) &&
+				Objects.equals(requestIdentity, that.requestIdentity);
 	}
 
 	/**
@@ -190,7 +223,7 @@ public class ServiceBrokerRequest {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(platformInstanceId, apiInfoLocation, originatingIdentity);
+		return Objects.hash(platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 	}
 
 	@Override
@@ -198,7 +231,8 @@ public class ServiceBrokerRequest {
 		return "ServiceBrokerRequest{" +
 				"platformInstanceId='" + platformInstanceId + '\'' +
 				", apiInfoLocation='" + apiInfoLocation + '\'' +
-				", originatingIdentity=" + originatingIdentity +
+				", originatingIdentity=" + originatingIdentity + '\'' +
+				", requestIdentity=" + requestIdentity +
 				'}';
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
@@ -107,13 +107,13 @@ public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	public CreateServiceInstanceBindingRequest(String serviceInstanceId, String serviceDefinitionId, String planId,
-			String bindingId, ServiceDefinition serviceDefinition, Plan plan,
-			boolean asyncAccepted, BindResource bindResource,
-			Map<String, Object> parameters, Context context,
-			String platformInstanceId, String apiInfoLocation, Context originatingIdentity) {
-		super(asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity);
+			String bindingId, ServiceDefinition serviceDefinition, Plan plan, boolean asyncAccepted,
+			BindResource bindResource, Map<String, Object> parameters, Context context, String platformInstanceId,
+			String apiInfoLocation, Context originatingIdentity, String requestIdentity) {
+		super(asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.serviceInstanceId = serviceInstanceId;
 		this.serviceDefinitionId = serviceDefinitionId;
 		this.planId = planId;
@@ -418,6 +418,8 @@ public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 
 		private Context originatingIdentity;
 
+		private String requestIdentity;
+
 		private CreateServiceInstanceBindingRequestBuilder() {
 		}
 
@@ -593,14 +595,26 @@ public class CreateServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public CreateServiceInstanceBindingRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link CreateServiceInstanceBindingRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal CreateServiceInstanceBindingRequest}
 		 */
 		public CreateServiceInstanceBindingRequest build() {
-			return new CreateServiceInstanceBindingRequest(serviceInstanceId, serviceDefinitionId, planId,
-					bindingId, serviceDefinition, plan, asyncAccepted, bindResource, parameters, context,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+			return new CreateServiceInstanceBindingRequest(serviceInstanceId, serviceDefinitionId, planId, bindingId,
+					serviceDefinition, plan, asyncAccepted, bindResource, parameters, context, platformInstanceId,
+					apiInfoLocation, originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
@@ -72,12 +72,12 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	public DeleteServiceInstanceBindingRequest(String serviceInstanceId, String serviceDefinitionId, String planId,
-			String bindingId, ServiceDefinition serviceDefinition, Plan plan,
-			boolean acceptsAsync, String platformInstanceId, String apiInfoLocation,
-			Context originatingIdentity) {
-		super(acceptsAsync, platformInstanceId, apiInfoLocation, originatingIdentity);
+			String bindingId, ServiceDefinition serviceDefinition, Plan plan, boolean acceptsAsync,
+			String platformInstanceId, String apiInfoLocation, Context originatingIdentity, String requestIdentity) {
+		super(acceptsAsync, platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.serviceInstanceId = serviceInstanceId;
 		this.serviceDefinitionId = serviceDefinitionId;
 		this.planId = planId;
@@ -247,6 +247,8 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 
 		private Context originatingIdentity;
 
+		private String requestIdentity;
+
 		private ServiceDefinition serviceDefinition;
 
 		private Plan plan;
@@ -376,14 +378,26 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public DeleteServiceInstanceBindingRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link DeleteServiceInstanceBindingRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal DeleteServiceInstanceBindingRequest}
 		 */
 		public DeleteServiceInstanceBindingRequest build() {
 			return new DeleteServiceInstanceBindingRequest(serviceInstanceId, serviceDefinitionId, planId,
-					bindingId, serviceDefinition, plan, asyncAccepted,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+					bindingId, serviceDefinition, plan, asyncAccepted, platformInstanceId, apiInfoLocation,
+					originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequest.java
@@ -56,11 +56,12 @@ public class GetLastServiceBindingOperationRequest extends ServiceBrokerRequest 
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	public GetLastServiceBindingOperationRequest(String serviceInstanceId, String bindingId, String serviceDefinitionId,
-			String planId, String operation, String platformInstanceId,
-			String apiInfoLocation, Context originatingIdentity) {
-		super(platformInstanceId, apiInfoLocation, originatingIdentity);
+			String planId, String operation, String platformInstanceId, String apiInfoLocation,
+			Context originatingIdentity, String requestIdentity) {
+		super(platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.serviceInstanceId = serviceInstanceId;
 		this.bindingId = bindingId;
 		this.serviceDefinitionId = serviceDefinitionId;
@@ -158,7 +159,8 @@ public class GetLastServiceBindingOperationRequest extends ServiceBrokerRequest 
 			return false;
 		}
 		GetLastServiceBindingOperationRequest that = (GetLastServiceBindingOperationRequest) o;
-		return Objects.equals(serviceInstanceId, that.serviceInstanceId) &&
+		return that.canEqual(this) &&
+				Objects.equals(serviceInstanceId, that.serviceInstanceId) &&
 				Objects.equals(bindingId, that.bindingId) &&
 				Objects.equals(serviceDefinitionId, that.serviceDefinitionId) &&
 				Objects.equals(planId, that.planId) &&
@@ -207,6 +209,8 @@ public class GetLastServiceBindingOperationRequest extends ServiceBrokerRequest 
 		private String apiInfoLocation;
 
 		private Context originatingIdentity;
+
+		private String requestIdentity;
 
 		private GetLastServiceBindingOperationRequestBuilder() {
 		}
@@ -307,13 +311,25 @@ public class GetLastServiceBindingOperationRequest extends ServiceBrokerRequest 
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public GetLastServiceBindingOperationRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link GetLastServiceBindingOperationRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal GetLastServiceOperationRequest}
 		 */
 		public GetLastServiceBindingOperationRequest build() {
 			return new GetLastServiceBindingOperationRequest(serviceInstanceId, bindingId, serviceDefinitionId, planId,
-					operation, platformInstanceId, apiInfoLocation, originatingIdentity);
+					operation, platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequest.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
  * body passed to the service broker by the platform.
  *
  * @author Scott Frederick
+ * @author Roy Clarkson
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md">Open Service Broker API
  * 		specification</a>
  */
@@ -46,10 +47,11 @@ public class GetServiceInstanceBindingRequest extends ServiceBrokerRequest {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
-	public GetServiceInstanceBindingRequest(String serviceInstanceId, String bindingId,
-			String platformInstanceId, String apiInfoLocation, Context originatingIdentity) {
-		super(platformInstanceId, apiInfoLocation, originatingIdentity);
+	public GetServiceInstanceBindingRequest(String serviceInstanceId, String bindingId, String platformInstanceId,
+			String apiInfoLocation, Context originatingIdentity, String requestIdentity) {
+		super(platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.serviceInstanceId = serviceInstanceId;
 		this.bindingId = bindingId;
 	}
@@ -105,7 +107,8 @@ public class GetServiceInstanceBindingRequest extends ServiceBrokerRequest {
 			return false;
 		}
 		GetServiceInstanceBindingRequest that = (GetServiceInstanceBindingRequest) o;
-		return Objects.equals(serviceInstanceId, that.serviceInstanceId) &&
+		return that.canEqual(this) &&
+				Objects.equals(serviceInstanceId, that.serviceInstanceId) &&
 				Objects.equals(bindingId, that.bindingId);
 	}
 
@@ -142,6 +145,8 @@ public class GetServiceInstanceBindingRequest extends ServiceBrokerRequest {
 		private String apiInfoLocation;
 
 		private Context originatingIdentity;
+
+		private String requestIdentity;
 
 		private GetServiceInstanceBindingRequestBuilder() {
 		}
@@ -207,13 +212,25 @@ public class GetServiceInstanceBindingRequest extends ServiceBrokerRequest {
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public GetServiceInstanceBindingRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link GetServiceInstanceBindingRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal GetServiceInstanceBindingRequest}
 		 */
 		public GetServiceInstanceBindingRequest build() {
-			return new GetServiceInstanceBindingRequest(serviceInstanceId, bindingId,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+			return new GetServiceInstanceBindingRequest(serviceInstanceId, bindingId, platformInstanceId,
+					apiInfoLocation, originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
@@ -31,6 +31,7 @@ import org.springframework.util.CollectionUtils;
  * Details of a request that supports arbitrary parameters and asynchronous behavior.
  *
  * @author Scott Frederick
+ * @author Roy Clarkson
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class AsyncParameterizedServiceInstanceRequest extends AsyncServiceBrokerRequest {
@@ -43,7 +44,7 @@ public abstract class AsyncParameterizedServiceInstanceRequest extends AsyncServ
 	 * Construct a new {@link AsyncParameterizedServiceInstanceRequest}
 	 */
 	protected AsyncParameterizedServiceInstanceRequest() {
-		this(null, null, false, null, null, null);
+		this(null, null, false, null, null, null, null);
 	}
 
 	/**
@@ -55,11 +56,12 @@ public abstract class AsyncParameterizedServiceInstanceRequest extends AsyncServ
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	protected AsyncParameterizedServiceInstanceRequest(Map<String, Object> parameters, Context context,
-			boolean asyncAccepted, String platformInstanceId,
-			String apiInfoLocation, Context originatingIdentity) {
-		super(asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity);
+			boolean asyncAccepted, String platformInstanceId, String apiInfoLocation, Context originatingIdentity,
+			String requestIdentity) {
+		super(asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		if (!CollectionUtils.isEmpty(parameters)) {
 			this.parameters.putAll(parameters);
 		}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
@@ -40,6 +40,7 @@ import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
  *
  * @author sgreenberg@pivotal.io
  * @author Scott Frederick
+ * @author Roy Clarkson
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#request-2">Open Service
  * 		Broker API specification</a>
  */
@@ -79,7 +80,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 * Construct a new {@link CreateServiceInstanceRequest}
 	 */
 	public CreateServiceInstanceRequest() {
-		this(null, null, null, null, null, null, null, false, null, null, null);
+		this(null, null, null, null, null, null, null, false, null, null, null, null);
 	}
 
 	/**
@@ -96,21 +97,22 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	public CreateServiceInstanceRequest(String serviceDefinitionId, String serviceInstanceId, String planId,
-			ServiceDefinition serviceDefinition, Plan plan,
-			Map<String, Object> parameters, Context context, boolean asyncAccepted,
-			String platformInstanceId, String apiInfoLocation, Context originatingIdentity) {
+			ServiceDefinition serviceDefinition, Plan plan, Map<String, Object> parameters, Context context,
+			boolean asyncAccepted, String platformInstanceId, String apiInfoLocation, Context originatingIdentity,
+			String requestIdentity) {
 		this(serviceDefinitionId, serviceInstanceId, planId, serviceDefinition, plan, parameters, context,
-				asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity, null, null);
+				asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity, null, null);
 	}
 
 	private CreateServiceInstanceRequest(String serviceDefinitionId, String serviceInstanceId, String planId,
-			ServiceDefinition serviceDefinition, Plan plan,
-			Map<String, Object> parameters, Context context, boolean asyncAccepted,
-			String platformInstanceId, String apiInfoLocation,
-			Context originatingIdentity, String organizationGuid, String spaceGuid) {
-		super(parameters, context, asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity);
+			ServiceDefinition serviceDefinition, Plan plan, Map<String, Object> parameters, Context context,
+			boolean asyncAccepted, String platformInstanceId, String apiInfoLocation, Context originatingIdentity,
+			String requestIdentity, String organizationGuid, String spaceGuid) {
+		super(parameters, context, asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity,
+				requestIdentity);
 		this.serviceDefinitionId = serviceDefinitionId;
 		this.serviceInstanceId = serviceInstanceId;
 		this.planId = planId;
@@ -371,6 +373,8 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 
 		private Context originatingIdentity;
 
+		private String requestIdentity;
+
 		private CreateServiceInstanceRequestBuilder() {
 		}
 
@@ -521,14 +525,26 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public CreateServiceInstanceRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link CreateServiceInstanceRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal CreateServiceInstanceRequest}
 		 */
 		public CreateServiceInstanceRequest build() {
 			return new CreateServiceInstanceRequest(serviceDefinitionId, serviceInstanceId, planId,
-					serviceDefinition, plan, parameters, context, asyncAccepted,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+					serviceDefinition, plan, parameters, context, asyncAccepted, platformInstanceId, apiInfoLocation
+					, originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
  *
  * @author krujos
  * @author Scott Frederick
+ * @author Roy Clarkson
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#request-6">Open Service
  * 		Broker API specification</a>
  */
@@ -67,12 +68,12 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	public DeleteServiceInstanceRequest(String serviceInstanceId, String serviceDefinitionId,
-			String planId, ServiceDefinition serviceDefinition, Plan plan,
-			boolean asyncAccepted, String platformInstanceId,
-			String apiInfoLocation, Context originatingIdentity) {
-		super(asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity);
+			String planId, ServiceDefinition serviceDefinition, Plan plan, boolean asyncAccepted,
+			String platformInstanceId, String apiInfoLocation, Context originatingIdentity, String requestIdentity) {
+		super(asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.serviceInstanceId = serviceInstanceId;
 		this.serviceDefinitionId = serviceDefinitionId;
 		this.planId = planId;
@@ -230,6 +231,8 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 
 		private Context originatingIdentity;
 
+		private String requestIdentity;
+
 		private DeleteServiceInstanceRequestBuilder() {
 		}
 
@@ -343,14 +346,26 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public DeleteServiceInstanceRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link DeleteServiceInstanceRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal DeleteServiceInstanceRequest}
 		 */
 		public DeleteServiceInstanceRequest build() {
 			return new DeleteServiceInstanceRequest(serviceInstanceId, serviceDefinitionId, planId,
-					serviceDefinition, plan, asyncAccepted,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+					serviceDefinition, plan, asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity,
+					requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequest.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
  * body passed to the service broker by the platform.
  *
  * @author Scott Frederick
+ * @author Roy Clarkson
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#request-1">Open Service
  * 		Broker API specification</a>
  */
@@ -52,12 +53,12 @@ public class GetLastServiceOperationRequest extends ServiceBrokerRequest {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	public GetLastServiceOperationRequest(String serviceInstanceId, String serviceDefinitionId, String planId,
-			String operation,
-			String platformInstanceId, String apiInfoLocation,
-			Context originatingIdentity) {
-		super(platformInstanceId, apiInfoLocation, originatingIdentity);
+			String operation, String platformInstanceId, String apiInfoLocation, Context originatingIdentity,
+			String requestIdentity) {
+		super(platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.serviceInstanceId = serviceInstanceId;
 		this.serviceDefinitionId = serviceDefinitionId;
 		this.planId = planId;
@@ -140,7 +141,8 @@ public class GetLastServiceOperationRequest extends ServiceBrokerRequest {
 			return false;
 		}
 		GetLastServiceOperationRequest that = (GetLastServiceOperationRequest) o;
-		return Objects.equals(serviceInstanceId, that.serviceInstanceId) &&
+		return that.canEqual(this) &&
+				Objects.equals(serviceInstanceId, that.serviceInstanceId) &&
 				Objects.equals(serviceDefinitionId, that.serviceDefinitionId) &&
 				Objects.equals(planId, that.planId) &&
 				Objects.equals(operation, that.operation);
@@ -185,6 +187,8 @@ public class GetLastServiceOperationRequest extends ServiceBrokerRequest {
 		private String apiInfoLocation;
 
 		private Context originatingIdentity;
+
+		private String requestIdentity;
 
 		private GetLastServiceOperationRequestBuilder() {
 		}
@@ -273,14 +277,25 @@ public class GetLastServiceOperationRequest extends ServiceBrokerRequest {
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public GetLastServiceOperationRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link GetLastServiceOperationRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal GetLastServiceOperationRequest}
 		 */
 		public GetLastServiceOperationRequest build() {
 			return new GetLastServiceOperationRequest(serviceInstanceId, serviceDefinitionId, planId,
-					operation,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+					operation, platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequest.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
  * body passed to the service broker by the platform.
  *
  * @author Scott Frederick
+ * @author Roy Clarkson
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md">Open Service Broker API
  * 		specification</a>
  */
@@ -43,10 +44,11 @@ public class GetServiceInstanceRequest extends ServiceBrokerRequest {
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from server
 	 */
 	public GetServiceInstanceRequest(String serviceInstanceId, String platformInstanceId,
-			String apiInfoLocation, Context originatingIdentity) {
-		super(platformInstanceId, apiInfoLocation, originatingIdentity);
+			String apiInfoLocation, Context originatingIdentity, String requestIdentity) {
+		super(platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		this.serviceInstanceId = serviceInstanceId;
 	}
 
@@ -88,7 +90,8 @@ public class GetServiceInstanceRequest extends ServiceBrokerRequest {
 			return false;
 		}
 		GetServiceInstanceRequest that = (GetServiceInstanceRequest) o;
-		return Objects.equals(serviceInstanceId, that.serviceInstanceId);
+		return that.canEqual(this) &&
+				Objects.equals(serviceInstanceId, that.serviceInstanceId);
 	}
 
 	@Override
@@ -121,6 +124,8 @@ public class GetServiceInstanceRequest extends ServiceBrokerRequest {
 		private String apiInfoLocation;
 
 		private Context originatingIdentity;
+
+		private String requestIdentity;
 
 		private GetServiceInstanceRequestBuilder() {
 		}
@@ -174,13 +179,25 @@ public class GetServiceInstanceRequest extends ServiceBrokerRequest {
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public GetServiceInstanceRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link GetServiceInstanceRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal GetServiceInstanceRequest}
 		 */
 		public GetServiceInstanceRequest build() {
 			return new GetServiceInstanceRequest(serviceInstanceId,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+					platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
  * body passed to the service broker by the platform.
  *
  * @author Scott Frederick
+ * @author Roy Clarkson
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#request-3">Open Service
  * 		Broker API specification</a>
  */
@@ -65,7 +66,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 * Construct a new {@link UpdateServiceInstanceRequest}
 	 */
 	public UpdateServiceInstanceRequest() {
-		this(null, null, null, null, null, null, null, null, false, null, null, null);
+		this(null, null, null, null, null, null, null, null, false, null, null, null, null);
 	}
 
 	/**
@@ -83,13 +84,14 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 * @param platformInstanceId the platform instance ID
 	 * @param apiInfoLocation location of the API info endpoint of the platform instance
 	 * @param originatingIdentity identity of the user that initiated the request from the platform
+	 * @param requestIdentity identity of the request sent from the platform
 	 */
 	public UpdateServiceInstanceRequest(String serviceDefinitionId, String serviceInstanceId, String planId,
-			ServiceDefinition serviceDefinition, Plan plan,
-			PreviousValues previousValues, Map<String, Object> parameters,
-			Context context, boolean asyncAccepted,
-			String platformInstanceId, String apiInfoLocation, Context originatingIdentity) {
-		super(parameters, context, asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity);
+			ServiceDefinition serviceDefinition, Plan plan, PreviousValues previousValues,
+			Map<String, Object> parameters, Context context, boolean asyncAccepted, String platformInstanceId,
+			String apiInfoLocation, Context originatingIdentity, String requestIdentity) {
+		super(parameters, context, asyncAccepted, platformInstanceId, apiInfoLocation, originatingIdentity,
+				requestIdentity);
 		this.serviceDefinitionId = serviceDefinitionId;
 		this.serviceInstanceId = serviceInstanceId;
 		this.planId = planId;
@@ -351,6 +353,8 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 
 		private Context originatingIdentity;
 
+		private String requestIdentity;
+
 		private UpdateServiceInstanceRequestBuilder() {
 		}
 
@@ -515,6 +519,18 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 		}
 
 		/**
+		 * Set the identity of the request sent from the platform
+		 *
+		 * @param requestIdentity the request identity
+		 * @return the builder
+		 * @see #getRequestIdentity()
+		 */
+		public UpdateServiceInstanceRequestBuilder requestIdentity(String requestIdentity) {
+			this.requestIdentity = requestIdentity;
+			return this;
+		}
+
+		/**
 		 * Construct a {@link UpdateServiceInstanceRequest} from the provided values.
 		 *
 		 * @return the newly constructed {@literal UpdateServiceInstanceRequest}
@@ -522,7 +538,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 		public UpdateServiceInstanceRequest build() {
 			return new UpdateServiceInstanceRequest(serviceDefinitionId, serviceInstanceId, planId,
 					serviceDefinition, plan, previousValues, parameters, context, asyncAccepted,
-					platformInstanceId, apiInfoLocation, originatingIdentity);
+					platformInstanceId, apiInfoLocation, originatingIdentity, requestIdentity);
 		}
 
 	}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/BaseControllerTest.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.servicebroker.controller;
 
-import java.util.Base64;
-
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerInvalidOriginatingIdentityException;
@@ -26,6 +24,7 @@ import org.springframework.cloud.servicebroker.model.Context;
 import org.springframework.cloud.servicebroker.model.KubernetesContext;
 import org.springframework.cloud.servicebroker.model.PlatformContext;
 import org.springframework.cloud.servicebroker.model.ServiceBrokerRequest;
+import org.springframework.util.Base64Utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -87,7 +86,7 @@ public class BaseControllerTest {
 	}
 
 	private String encode(String json) {
-		return Base64.getEncoder().encodeToString(json.getBytes());
+		return Base64Utils.encodeToString(json.getBytes());
 	}
 
 	private static class TestBaseController extends BaseController {
@@ -101,7 +100,7 @@ public class BaseControllerTest {
 			};
 
 			configureCommonRequestFields(request, "platform-instance-id", "api-info-location",
-					originatingIdentityString)
+					originatingIdentityString, "request-id")
 					.block();
 
 			return request.getOriginatingIdentity();

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerRequestTest.java
@@ -50,12 +50,13 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.build();
 
 		ServiceInstanceBindingController controller = createControllerUnderTest(expectedRequest);
 
 		controller.createServiceInstanceBinding(pathVariables, "service-instance-id", "binding-id",
-				true, "api-info-location", encodeOriginatingIdentity(identityContext), parsedRequest);
+				true, "api-info-location", encodeOriginatingIdentity(identityContext), "request-id", parsedRequest);
 	}
 
 	@Test
@@ -67,7 +68,8 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 		ServiceInstanceBindingController controller = createControllerUnderTest();
 
 		assertThrows(ServiceDefinitionDoesNotExistException.class, () ->
-				controller.createServiceInstanceBinding(pathVariables, null, null, false, null, null, createRequest)
+				controller.createServiceInstanceBinding(pathVariables, null, null, false, null, null,
+						null, createRequest)
 						.block());
 	}
 
@@ -83,7 +85,8 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 
 		assertThrows(ServiceDefinitionPlanDoesNotExistException.class, () ->
 				controller.createServiceInstanceBinding(pathVariables, null, null,
-						false, null, encodeOriginatingIdentity(identityContext), createRequest).block());
+						false, null, encodeOriginatingIdentity(identityContext), "request-id", createRequest)
+						.block());
 	}
 
 
@@ -105,12 +108,13 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.build();
 
 		ServiceInstanceBindingController controller = createControllerUnderTest(expectedRequest);
 
 		controller.getServiceInstanceBinding(pathVariables, "service-instance-id", "binding-id",
-				"api-info-location", encodeOriginatingIdentity(identityContext));
+				"api-info-location", encodeOriginatingIdentity(identityContext), "request-id");
 	}
 
 	@Test
@@ -124,6 +128,7 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.serviceDefinition(serviceDefinition)
 				.plan(plan)
 				.build();
@@ -132,7 +137,7 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 
 		controller.deleteServiceInstanceBinding(pathVariables, "service-instance-id", "binding-id",
 				serviceDefinition.getId(), "plan-id", true,
-				"api-info-location", encodeOriginatingIdentity(identityContext));
+				"api-info-location", encodeOriginatingIdentity(identityContext), "request-id");
 	}
 
 	@Test
@@ -142,7 +147,8 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 		assertThrows(ServiceDefinitionDoesNotExistException.class, () ->
 				controller
 						.deleteServiceInstanceBinding(pathVariables, null, null, "unknown-service-definition-id", null,
-								false, null, null).block());
+								false, null, null, null)
+						.block());
 	}
 
 	@Test
@@ -151,7 +157,8 @@ public class ServiceInstanceBindingControllerRequestTest extends ControllerReque
 
 		assertThrows(ServiceDefinitionPlanDoesNotExistException.class, () ->
 				controller.deleteServiceInstanceBinding(pathVariables, null, null, "service-definition-id",
-						"unknown-plan-id", false, null, null).block());
+						"unknown-plan-id", false, null, null, null)
+						.block());
 	}
 
 	private ServiceInstanceBindingController createControllerUnderTest(ServiceBrokerRequest expectedRequest) {

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerResponseCodeTest.java
@@ -108,7 +108,7 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 				.build();
 
 		ResponseEntity<CreateServiceInstanceBindingResponse> responseEntity = controller
-				.createServiceInstanceBinding(pathVariables, null, null, false, null, null,
+				.createServiceInstanceBinding(pathVariables, null, null, false, null, null, null,
 						createRequest)
 				.block();
 
@@ -142,7 +142,7 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 				.willReturn(responseMono);
 
 		ResponseEntity<GetServiceInstanceBindingResponse> responseEntity = controller
-				.getServiceInstanceBinding(pathVariables, null, null, null, null)
+				.getServiceInstanceBinding(pathVariables, null, null, null, null, null)
 				.block();
 
 		assertThat(responseEntity).isNotNull();
@@ -156,7 +156,7 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 				.willThrow(new ServiceInstanceBindingDoesNotExistException("binding-id"));
 
 		ResponseEntity<GetServiceInstanceBindingResponse> responseEntity = controller
-				.getServiceInstanceBinding(pathVariables, null, null, null, null)
+				.getServiceInstanceBinding(pathVariables, null, null, null, null, null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -169,7 +169,7 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 
 		ResponseEntity<GetServiceInstanceBindingResponse> responseEntity = controller
 				.getServiceInstanceBinding(pathVariables, "nonexistent-service-id", "nonexistent-binding-id", null,
-						null)
+						null, null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -208,7 +208,7 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 
 		ResponseEntity<DeleteServiceInstanceBindingResponse> responseEntity = controller
 				.deleteServiceInstanceBinding(pathVariables, null, null, "service-definition-id",
-						"service-definition-plan-id", false, null, null)
+						"service-definition-plan-id", false, null, null, null)
 				.block();
 
 		assertThat(responseEntity).isNotNull();
@@ -227,7 +227,7 @@ public class ServiceInstanceBindingControllerResponseCodeTest {
 
 		ResponseEntity<DeleteServiceInstanceBindingResponse> responseEntity = controller
 				.deleteServiceInstanceBinding(pathVariables, null, null, "service-definition-id",
-						"service-definition-plan-id", false, null, null)
+						"service-definition-plan-id", false, null, null, null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.GONE);

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerRequestTest.java
@@ -53,6 +53,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.serviceDefinition(serviceDefinition)
 				.plan(plan)
 				.build();
@@ -60,7 +61,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 		ServiceInstanceController controller = createControllerUnderTest(expectedRequest);
 
 		controller.createServiceInstance(pathVariables, "service-instance-id", true,
-				"api-info-location", encodeOriginatingIdentity(identityContext), parsedRequest)
+				"api-info-location", encodeOriginatingIdentity(identityContext), "request-id", parsedRequest)
 				.block();
 	}
 
@@ -83,7 +84,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 
 		assertThrows(ServiceDefinitionDoesNotExistException.class, () ->
 				controller.createServiceInstance(pathVariables, null, false,
-						null, null, createRequest)
+						null, null, null, createRequest)
 						.block());
 	}
 
@@ -98,7 +99,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 
 		assertThrows(ServiceDefinitionPlanDoesNotExistException.class, () ->
 				controller.createServiceInstance(pathVariables, null, false,
-						null, null, createRequest)
+						null, null, null, createRequest)
 						.block());
 	}
 
@@ -109,12 +110,13 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.build();
 
 		ServiceInstanceController controller = createControllerUnderTest(expectedRequest);
 
 		controller.getServiceInstance(pathVariables, "service-instance-id",
-				"api-info-location", encodeOriginatingIdentity(identityContext))
+				"api-info-location", encodeOriginatingIdentity(identityContext), "request-id")
 				.block();
 	}
 
@@ -128,13 +130,14 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.build();
 
 		ServiceInstanceController controller = createControllerUnderTest(expectedRequest);
 
 		controller.getServiceInstanceLastOperation(pathVariables, "service-instance-id",
 				"service-definition-id", "plan-id", "operation",
-				"api-info-location", encodeOriginatingIdentity(identityContext))
+				"api-info-location", encodeOriginatingIdentity(identityContext), "request-id")
 				.block();
 	}
 
@@ -148,6 +151,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.serviceDefinition(serviceDefinition)
 				.plan(plan)
 				.build();
@@ -156,7 +160,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 
 		controller.deleteServiceInstance(pathVariables, "service-instance-id",
 				"service-definition-id", "plan-id", true, "api-info-location",
-				encodeOriginatingIdentity(identityContext))
+				encodeOriginatingIdentity(identityContext), "request-id")
 				.block();
 	}
 
@@ -172,7 +176,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 
 		assertThrows(ServiceDefinitionDoesNotExistException.class, () ->
 				controller.deleteServiceInstance(pathVariables, null, "unknown-service-definition-id", null, true, null,
-						encodeOriginatingIdentity(identityContext))
+						encodeOriginatingIdentity(identityContext), "request-id")
 						.block());
 	}
 
@@ -188,8 +192,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 
 		assertThrows(ServiceDefinitionPlanDoesNotExistException.class, () ->
 				controller.deleteServiceInstance(pathVariables, null, "service-definition-id", "unknown-plan-id", true,
-						null,
-						encodeOriginatingIdentity(identityContext))
+						null, encodeOriginatingIdentity(identityContext), "request-id")
 						.block());
 	}
 
@@ -203,6 +206,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("api-info-location")
 				.originatingIdentity(identityContext)
+				.requestIdentity("request-id")
 				.serviceDefinition(serviceDefinition)
 				.plan(plan)
 				.build();
@@ -210,7 +214,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 		ServiceInstanceController controller = createControllerUnderTest(expectedRequest);
 
 		controller.updateServiceInstance(pathVariables, "service-instance-id", true,
-				"api-info-location", encodeOriginatingIdentity(identityContext),
+				"api-info-location", encodeOriginatingIdentity(identityContext), "request-id",
 				parsedRequest)
 				.block();
 	}
@@ -235,7 +239,7 @@ public class ServiceInstanceControllerRequestTest extends ControllerRequestTest 
 
 		assertThrows(ServiceDefinitionDoesNotExistException.class, () ->
 				controller.updateServiceInstance(pathVariables, null, false,
-						null, null, updateRequest)
+						null, null, null, updateRequest)
 						.block());
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
@@ -128,7 +128,7 @@ public class ServiceInstanceControllerResponseCodeTest {
 				.build();
 
 		ResponseEntity<CreateServiceInstanceResponse> responseEntity = controller
-				.createServiceInstance(pathVariables, null, false, null, null,
+				.createServiceInstance(pathVariables, null, false, null, null, null,
 						createRequest)
 				.block();
 
@@ -164,7 +164,7 @@ public class ServiceInstanceControllerResponseCodeTest {
 				.willReturn(responseMono);
 
 		ResponseEntity<GetServiceInstanceResponse> responseEntity = controller
-				.getServiceInstance(pathVariables, null, null, null)
+				.getServiceInstance(pathVariables, null, null, null, null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(expectedStatus);
@@ -177,7 +177,7 @@ public class ServiceInstanceControllerResponseCodeTest {
 				.willReturn(Mono.error(new ServiceInstanceDoesNotExistException("instance does not exist")));
 
 		ResponseEntity<GetServiceInstanceResponse> responseEntity = controller
-				.getServiceInstance(pathVariables, null, "service-definition-id", null)
+				.getServiceInstance(pathVariables, null, "service-definition-id", null, null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -217,7 +217,7 @@ public class ServiceInstanceControllerResponseCodeTest {
 
 		ResponseEntity<DeleteServiceInstanceResponse> responseEntity = controller
 				.deleteServiceInstance(pathVariables, null, "service-definition-id", "service-definition-plan-id",
-						false, null, null)
+						false, null, null,null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(expectedStatus);
@@ -231,7 +231,7 @@ public class ServiceInstanceControllerResponseCodeTest {
 
 		ResponseEntity<DeleteServiceInstanceResponse> responseEntity = controller
 				.deleteServiceInstance(pathVariables, null, "service-definition-id", "service-definition-plan-id",
-						false, null, null)
+						false, null, null,null)
 				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.GONE);
@@ -274,7 +274,7 @@ public class ServiceInstanceControllerResponseCodeTest {
 				.build();
 
 		ResponseEntity<UpdateServiceInstanceResponse> responseEntity = controller
-				.updateServiceInstance(pathVariables, null, false, null, null,
+				.updateServiceInstance(pathVariables, null, false, null, null, null,
 						updateRequest)
 				.block();
 
@@ -320,7 +320,8 @@ public class ServiceInstanceControllerResponseCodeTest {
 
 		ResponseEntity<GetLastServiceOperationResponse> responseEntity = controller
 				.getServiceInstanceLastOperation(pathVariables, null, null, null, null,
-						null, null).block();
+						null, null, null)
+				.block();
 
 		assertThat(responseEntity.getStatusCode()).isEqualTo(expectedStatus);
 		assertThat(responseEntity.getBody()).isEqualTo(response);

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
@@ -54,6 +54,7 @@ public class CreateServiceInstanceBindingRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -83,6 +84,7 @@ public class CreateServiceInstanceBindingRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceDefinitionId()).isEqualTo("service-definition-id");
@@ -109,6 +111,7 @@ public class CreateServiceInstanceBindingRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
@@ -46,6 +46,7 @@ public class DeleteServiceInstanceBindingRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -63,6 +64,7 @@ public class DeleteServiceInstanceBindingRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
@@ -74,6 +76,7 @@ public class DeleteServiceInstanceBindingRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test
@@ -92,6 +95,7 @@ public class DeleteServiceInstanceBindingRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.plan(Plan.builder().build())
 				.serviceDefinition(ServiceDefinition.builder().build())
 				.build();

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequestTest.java
@@ -41,6 +41,7 @@ public class GetLastServiceBindingOperationRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -59,6 +60,7 @@ public class GetLastServiceBindingOperationRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
@@ -70,6 +72,7 @@ public class GetLastServiceBindingOperationRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
@@ -37,6 +37,7 @@ public class GetServiceInstanceBindingRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -51,6 +52,7 @@ public class GetServiceInstanceBindingRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
@@ -59,6 +61,7 @@ public class GetServiceInstanceBindingRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
@@ -51,6 +51,7 @@ public class CreateServiceInstanceRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -79,6 +80,7 @@ public class CreateServiceInstanceRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
@@ -98,6 +100,7 @@ public class CreateServiceInstanceRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test
@@ -129,6 +132,7 @@ public class CreateServiceInstanceRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.plan(Plan.builder().build())
 				.serviceDefinition(ServiceDefinition.builder().build())
 				.build();
@@ -143,6 +147,7 @@ public class CreateServiceInstanceRequestTest {
 		JsonPathAssert.assertThat(json).hasMapAtPath("$.context").hasSize(3);
 		JsonPathAssert.assertThat(json).hasPath("$.space_guid").isEqualTo("space-guid");
 		JsonPathAssert.assertThat(json).hasPath("$.organization_guid").isEqualTo("org-guid");
+		JsonPathAssert.assertThat(json).hasNoPath("$.request_identity");
 
 
 		// fields mapped outside of json body (typically http headers or request paths)
@@ -155,7 +160,9 @@ public class CreateServiceInstanceRequestTest {
 	public void serializesWithoutContextAccordingToOsbSpecs() {
 		CreateServiceInstanceRequest request = CreateServiceInstanceRequest.builder()
 				.serviceInstanceId("service-instance-id")
-				.serviceDefinitionId("service-definition-id").planId("plan-id").build();
+				.serviceDefinitionId("service-definition-id")
+				.planId("plan-id")
+				.build();
 
 		DocumentContext json = JsonUtils.toJsonPath(request);
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
@@ -45,6 +45,7 @@ public class DeleteServiceInstanceRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -62,6 +63,7 @@ public class DeleteServiceInstanceRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
@@ -72,6 +74,7 @@ public class DeleteServiceInstanceRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test
@@ -88,6 +91,7 @@ public class DeleteServiceInstanceRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.plan(Plan.builder().build())
 				.serviceDefinition(ServiceDefinition.builder().build())
 				.build();
@@ -100,6 +104,7 @@ public class DeleteServiceInstanceRequestTest {
 		JsonPathAssert.assertThat(json).hasPath("$.accepts_incomplete").isEqualTo(true);
 		//Other internals should not be polluting the JSON representation
 		JsonPathAssert.assertThat(json).hasMapAtPath("$").hasSize(3);
+		JsonPathAssert.assertThat(json).hasNoPath("$.request_identity");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
@@ -39,6 +39,7 @@ public class GetLastServiceOperationRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -56,16 +57,17 @@ public class GetLastServiceOperationRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
 		assertThat(request.getServiceDefinitionId()).isEqualTo("service-definition-id");
 		assertThat(request.getPlanId()).isEqualTo("plan-id");
 		assertThat(request.getOperation()).isEqualTo("working");
-
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
@@ -36,6 +36,7 @@ public class GetServiceInstanceRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -49,13 +50,14 @@ public class GetServiceInstanceRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
-
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
@@ -48,6 +48,7 @@ public class UpdateServiceInstanceRequestTest {
 		assertThat(request.getApiInfoLocation()).isNull();
 		assertThat(request.getPlatformInstanceId()).isNull();
 		assertThat(request.getOriginatingIdentity()).isNull();
+		assertThat(request.getRequestIdentity()).isNull();
 	}
 
 	@Test
@@ -77,6 +78,7 @@ public class UpdateServiceInstanceRequestTest {
 				.platformInstanceId("platform-instance-id")
 				.apiInfoLocation("https://api.example.com")
 				.originatingIdentity(originatingIdentity)
+				.requestIdentity("request-id")
 				.build();
 
 		assertThat(request.getServiceInstanceId()).isEqualTo("service-instance-id");
@@ -98,6 +100,7 @@ public class UpdateServiceInstanceRequestTest {
 		assertThat(request.getPlatformInstanceId()).isEqualTo("platform-instance-id");
 		assertThat(request.getApiInfoLocation()).isEqualTo("https://api.example.com");
 		assertThat(request.getOriginatingIdentity()).isEqualTo(originatingIdentity);
+		assertThat(request.getRequestIdentity()).isEqualTo("request-id");
 	}
 
 	@Test


### PR DESCRIPTION
If the request identity header is received in any request from the platform,
the broker will return the header in the response.

Resolves #234