### PR TITLE
Update sample spring security config

### DIFF
--- a/spring-cloud-open-service-broker-docs/src/test/java/com/example/servicebroker/ExampleSecurityConfig.java
+++ b/spring-cloud-open-service-broker-docs/src/test/java/com/example/servicebroker/ExampleSecurityConfig.java
@@ -16,6 +16,7 @@ public class ExampleSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
+				.csrf().disable()
 				.authorizeRequests()
 				.antMatchers("/v2/**").hasRole("ADMIN")
 				.and()
@@ -30,7 +31,7 @@ public class ExampleSecurityConfig extends WebSecurityConfigurerAdapter {
 	private UserDetails adminUser() {
 		return User
 				.withUsername("admin")
-				.password("supersecret")
+				.password("{noop}supersecret")
 				.roles("ADMIN")
 				.build();
 	}


### PR DESCRIPTION
Disabling csrf:

See https://docs.spring.io/spring-security/site/docs/5.3.0.RELEASE/reference/html5/#csrf-when
> Our recommendation is to use CSRF protection for any request that could be processed by a browser
> by normal users. If you are only creating a service that is used by non-browser clients,
> you will likely want to disable CSRF protection.

When CSRF is not explicitly disable, OSB endpoint with PUT/POST http methods get rejected

Using noop password encoder

See https://github.com/spring-cloud/spring-cloud-open-service-broker/issues/80#issuecomment-390252132 for more details about symptoms observed.