### PR TITLE
Upgrade spring-doc-resources

### DIFF
--- a/spring-cloud-open-service-broker-docs/build.gradle
+++ b/spring-cloud-open-service-broker-docs/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-tomcat")
     compile("io.projectreactor:reactor-core")
 
-    docs("io.spring.docresources:spring-doc-resources:0.2.0.RELEASE@zip")
+    docs("io.spring.docresources:spring-doc-resources:0.2.1.RELEASE@zip")
 }
 
 task prepareAsciidocBuild(type: Sync) {


### PR DESCRIPTION
Upgrade spring-doc-resources from version 0.2.0 to version 0.2.1
to get a bug fix (setting the display width in the HTML output).