### PR TITLE
Return the operation string in the response body for operations in progress

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/ControllerIntegrationTest.java
@@ -125,4 +125,10 @@ public abstract class ControllerIntegrationTest {
 		assertThat(description).contains(value);
 	}
 
+	protected void assertOperationIsEqualTo(EntityExchangeResult<byte[]> result, String value) {
+		String responseBody = new String(Objects.requireNonNull(result.getResponseBody()), StandardCharsets.UTF_8);
+		String operation = JsonPath.read(responseBody, "$.operation");
+		assertThat(operation).isEqualTo(value);
+	}
+
 }

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceBindingService.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceBindingService.java
@@ -50,7 +50,7 @@ public class TestServiceInstanceBindingService implements ServiceInstanceBinding
 	public Mono<CreateServiceInstanceBindingResponse> createServiceInstanceBinding(
 			CreateServiceInstanceBindingRequest request) {
 		if (IN_PROGRESS_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
-			return Mono.error(new ServiceBrokerCreateOperationInProgressException("still working"));
+			return Mono.error(new ServiceBrokerCreateOperationInProgressException("task_10"));
 		}
 		if (EXISTING_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
 			return Mono.just(CreateServiceInstanceAppBindingResponse.builder()
@@ -78,7 +78,7 @@ public class TestServiceInstanceBindingService implements ServiceInstanceBinding
 	public Mono<DeleteServiceInstanceBindingResponse> deleteServiceInstanceBinding(
 			DeleteServiceInstanceBindingRequest request) {
 		if (IN_PROGRESS_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
-			return Mono.error(new ServiceBrokerDeleteOperationInProgressException("still working"));
+			return Mono.error(new ServiceBrokerDeleteOperationInProgressException("task_10"));
 		}
 		if (UNKNOWN_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
 			return Mono.error(new ServiceInstanceDoesNotExistException(request.getServiceInstanceId()));
@@ -101,7 +101,7 @@ public class TestServiceInstanceBindingService implements ServiceInstanceBinding
 	@Override
 	public Mono<GetServiceInstanceBindingResponse> getServiceInstanceBinding(GetServiceInstanceBindingRequest request) {
 		if (IN_PROGRESS_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
-			return Mono.error(new ServiceBrokerOperationInProgressException("still working"));
+			return Mono.error(new ServiceBrokerOperationInProgressException("task_10"));
 		}
 		return Mono.just(GetServiceInstanceAppBindingResponse.builder()
 				.build());

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceService.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/TestServiceInstanceService.java
@@ -47,7 +47,7 @@ public class TestServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
 		if (IN_PROGRESS_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
-			return Mono.error(new ServiceBrokerCreateOperationInProgressException("still working"));
+			return Mono.error(new ServiceBrokerCreateOperationInProgressException("task_10"));
 		}
 		if (EXISTING_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
 			return Mono.just(CreateServiceInstanceResponse.builder()
@@ -69,7 +69,7 @@ public class TestServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public Mono<GetServiceInstanceResponse> getServiceInstance(GetServiceInstanceRequest request) {
 		if (IN_PROGRESS_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
-			return Mono.error(new ServiceBrokerOperationInProgressException("still working"));
+			return Mono.error(new ServiceBrokerOperationInProgressException("task_10"));
 		}
 		return Mono.just(GetServiceInstanceResponse.builder()
 				.build());
@@ -107,7 +107,7 @@ public class TestServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public Mono<DeleteServiceInstanceResponse> deleteServiceInstance(DeleteServiceInstanceRequest request) {
 		if (IN_PROGRESS_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
-			return Mono.error(new ServiceBrokerDeleteOperationInProgressException("still working"));
+			return Mono.error(new ServiceBrokerDeleteOperationInProgressException("task_10"));
 		}
 		if (UNKNOWN_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
 			return Mono.error(new ServiceInstanceDoesNotExistException(UNKNOWN_SERVICE_INSTANCE_ID));
@@ -127,7 +127,7 @@ public class TestServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public Mono<UpdateServiceInstanceResponse> updateServiceInstance(UpdateServiceInstanceRequest request) {
 		if (IN_PROGRESS_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
-			return Mono.error(new ServiceBrokerUpdateOperationInProgressException("still working"));
+			return Mono.error(new ServiceBrokerUpdateOperationInProgressException("task_10"));
 		}
 		if (UNKNOWN_SERVICE_INSTANCE_ID.equals(request.getServiceInstanceId())) {
 			return Mono.error(new ServiceInstanceDoesNotExistException(UNKNOWN_SERVICE_INSTANCE_ID));

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
@@ -148,8 +148,8 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
 				.expectStatus().isAccepted()
-				.expectBody().jsonPath("$.description").isNotEmpty()
-				.consumeWith(result -> assertDescriptionContains(result, "still working"));
+				.expectBody().jsonPath("$.operation").isNotEmpty()
+				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
 
 		verifyCreateBinding();
 	}
@@ -474,8 +474,8 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.exchange()
 				.expectStatus().isAccepted()
 				.expectBody()
-				.jsonPath("$.description").isNotEmpty()
-				.consumeWith(result -> assertDescriptionContains(result, "still working"));
+				.jsonPath("$.operation").isNotEmpty()
+				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
 
 		verifyDeleteBinding();
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
@@ -138,7 +138,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	void createBindingToAppWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceBindingService(new ServiceBrokerCreateOperationInProgressException("still working"));
+		setupServiceInstanceBindingService(new ServiceBrokerCreateOperationInProgressException("task_10"));
 
 		client.put().uri(buildCreateUrl(PLATFORM_INSTANCE_ID, true))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -149,7 +149,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.exchange()
 				.expectStatus().isAccepted()
 				.expectBody().jsonPath("$.operation").isNotEmpty()
-				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
+				.consumeWith(result -> assertOperationIsEqualTo(result, "task_10"));
 
 		verifyCreateBinding();
 	}
@@ -378,7 +378,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	@Test
 	void getBindingWithOperationInProgressFails() {
 		given(serviceInstanceBindingService.getServiceInstanceBinding(any(GetServiceInstanceBindingRequest.class)))
-				.willThrow(new ServiceBrokerOperationInProgressException("still working"));
+				.willThrow(new ServiceBrokerOperationInProgressException("task_10"));
 
 		client.get().uri(buildCreateUrl())
 				.accept(MediaType.APPLICATION_JSON)
@@ -466,7 +466,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	void deleteBindingWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceBindingService(new ServiceBrokerDeleteOperationInProgressException("still working"));
+		setupServiceInstanceBindingService(new ServiceBrokerDeleteOperationInProgressException("task_10"));
 
 		client.delete().uri(buildDeleteUrl(PLATFORM_INSTANCE_ID, true))
 				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
@@ -475,7 +475,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.expectStatus().isAccepted()
 				.expectBody()
 				.jsonPath("$.operation").isNotEmpty()
-				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
+				.consumeWith(result -> assertOperationIsEqualTo(result, "task_10"));
 
 		verifyDeleteBinding();
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
@@ -100,7 +100,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	void createServiceInstanceWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceService(new ServiceBrokerCreateOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerCreateOperationInProgressException("task_10"));
 
 		client.put().uri(buildCreateUpdateUrl(PLATFORM_INSTANCE_ID, true))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -112,7 +112,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.expectStatus().isAccepted()
 				.expectBody()
 				.jsonPath("$.operation").isNotEmpty()
-				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
+				.consumeWith(result -> assertOperationIsEqualTo(result, "task_10"));
 
 		verifyCreateServiceInstance();
 	}
@@ -402,7 +402,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 	@Test
 	void getServiceInstanceWithOperationInProgressFails() throws Exception {
-		setupServiceInstanceService(new ServiceBrokerOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerOperationInProgressException("task_10"));
 
 		client.get().uri(buildCreateUpdateUrl(PLATFORM_INSTANCE_ID, false))
 				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
@@ -411,7 +411,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.exchange()
 				.expectStatus().isNotFound()
 				.expectBody()
-				.consumeWith(result -> assertDescriptionContains(result, "operation=still working"));
+				.consumeWith(result -> assertDescriptionContains(result, "operation=task_10"));
 	}
 
 	@Test
@@ -441,7 +441,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	void deleteServiceInstanceWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceService(new ServiceBrokerDeleteOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerDeleteOperationInProgressException("task_10"));
 
 		client.delete().uri(buildDeleteUrl(PLATFORM_INSTANCE_ID, true))
 				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
@@ -451,7 +451,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.expectStatus().isAccepted()
 				.expectBody()
 				.jsonPath("$.operation").isNotEmpty()
-				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
+				.consumeWith(result -> assertOperationIsEqualTo(result, "task_10"));
 
 		verifyDeleteServiceInstance();
 	}
@@ -568,7 +568,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	void updateServiceInstanceWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceService(new ServiceBrokerUpdateOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerUpdateOperationInProgressException("task_10"));
 
 		client.patch().uri(buildCreateUpdateUrl(PLATFORM_INSTANCE_ID, true))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -580,7 +580,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.expectStatus().isAccepted()
 				.expectBody()
 				.jsonPath("$.operation").isNotEmpty()
-				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
+				.consumeWith(result -> assertOperationIsEqualTo(result, "task_10"));
 
 		verifyUpdateServiceInstance();
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
@@ -111,8 +111,8 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.exchange()
 				.expectStatus().isAccepted()
 				.expectBody()
-				.jsonPath("$.description").isNotEmpty()
-				.consumeWith(result -> assertDescriptionContains(result, "still working"));
+				.jsonPath("$.operation").isNotEmpty()
+				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
 
 		verifyCreateServiceInstance();
 	}
@@ -450,8 +450,8 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.exchange()
 				.expectStatus().isAccepted()
 				.expectBody()
-				.jsonPath("$.description").isNotEmpty()
-				.consumeWith(result -> assertDescriptionContains(result, "still working"));
+				.jsonPath("$.operation").isNotEmpty()
+				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
 
 		verifyDeleteServiceInstance();
 	}
@@ -579,8 +579,8 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.exchange()
 				.expectStatus().isAccepted()
 				.expectBody()
-				.jsonPath("$.description").isNotEmpty()
-				.consumeWith(result -> assertDescriptionContains(result, "still working"));
+				.jsonPath("$.operation").isNotEmpty()
+				.consumeWith(result -> assertOperationIsEqualTo(result, "still working"));
 
 		verifyUpdateServiceInstance();
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
@@ -163,7 +163,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	void createBindingToAppWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceBindingService(new ServiceBrokerCreateOperationInProgressException("still working"));
+		setupServiceInstanceBindingService(new ServiceBrokerCreateOperationInProgressException("task_10"));
 
 		MvcResult mvcResult = mockMvc.perform(put(buildCreateUrl(PLATFORM_INSTANCE_ID, true))
 				.content(createRequestBody)
@@ -177,7 +177,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.operation", is("still working")));
+				.andExpect(jsonPath("$.operation", is("task_10")));
 
 		verifyCreateBinding();
 	}
@@ -401,7 +401,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	@Test
 	void getBindingWithOperationInProgressFails() throws Exception {
 		given(serviceInstanceBindingService.getServiceInstanceBinding(any(GetServiceInstanceBindingRequest.class)))
-				.willThrow(new ServiceBrokerOperationInProgressException("still working"));
+				.willThrow(new ServiceBrokerOperationInProgressException("task_10"));
 
 		MvcResult mvcResult = mockMvc.perform(get(buildCreateUrl())
 				.accept(MediaType.APPLICATION_JSON)
@@ -445,7 +445,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	void deleteBindingWithoutAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceBindingService(new ServiceBrokerDeleteOperationInProgressException("still working"));
+		setupServiceInstanceBindingService(new ServiceBrokerDeleteOperationInProgressException("task_10"));
 
 		MvcResult mvcResult = mockMvc.perform(delete(buildDeleteUrl(PLATFORM_INSTANCE_ID, false))
 				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
@@ -457,7 +457,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.operation", is("still working")));
+				.andExpect(jsonPath("$.operation", is("task_10")));
 
 		then(serviceInstanceBindingService)
 				.should()

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
@@ -177,7 +177,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.description", containsString("still working")));
+				.andExpect(jsonPath("$.operation", is("still working")));
 
 		verifyCreateBinding();
 	}
@@ -457,7 +457,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.description", containsString("still working")));
+				.andExpect(jsonPath("$.operation", is("still working")));
 
 		then(serviceInstanceBindingService)
 				.should()

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -112,7 +112,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	void createServiceInstanceWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceService(new ServiceBrokerCreateOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerCreateOperationInProgressException("task_10"));
 
 		MvcResult mvcResult = mockMvc.perform(put(buildCreateUpdateUrl(PLATFORM_INSTANCE_ID, true))
 				.content(createRequestBody)
@@ -126,7 +126,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.operation", is("still working")));
+				.andExpect(jsonPath("$.operation", is("task_10")));
 
 		verifyCreateServiceInstance();
 	}
@@ -448,7 +448,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 	@Test
 	void getServiceInstanceWithOperationInProgressFails() throws Exception {
-		setupServiceInstanceService(new ServiceBrokerOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerOperationInProgressException("task_10"));
 
 		MvcResult mvcResult = mockMvc.perform(get(buildCreateUpdateUrl(PLATFORM_INSTANCE_ID, false))
 				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
@@ -460,7 +460,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.description", containsString("still working")));
+				.andExpect(jsonPath("$.description", containsString("task_10")));
 	}
 
 	@Test
@@ -492,7 +492,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	void deleteServiceInstanceWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceService(new ServiceBrokerDeleteOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerDeleteOperationInProgressException("task_10"));
 
 		MvcResult mvcResult = mockMvc.perform(delete(buildDeleteUrl(PLATFORM_INSTANCE_ID, true))
 				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
@@ -504,7 +504,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.operation", is("still working")));
+				.andExpect(jsonPath("$.operation", is("task_10")));
 
 		verifyDeleteServiceInstance();
 	}
@@ -626,7 +626,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	void updateServiceInstanceWithAsyncAndHeadersOperationInProgress() throws Exception {
 		setupCatalogService();
 
-		setupServiceInstanceService(new ServiceBrokerUpdateOperationInProgressException("still working"));
+		setupServiceInstanceService(new ServiceBrokerUpdateOperationInProgressException("task_10"));
 
 		MvcResult mvcResult = mockMvc.perform(patch(buildCreateUpdateUrl(PLATFORM_INSTANCE_ID, true))
 				.content(updateRequestBody)
@@ -639,7 +639,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.operation", is("still working")));
+				.andExpect(jsonPath("$.operation", is("task_10")));
 
 		verifyUpdateServiceInstance();
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -126,7 +126,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.description", containsString("still working")));
+				.andExpect(jsonPath("$.operation", is("still working")));
 
 		verifyCreateServiceInstance();
 	}
@@ -504,7 +504,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.description", containsString("still working")));
+				.andExpect(jsonPath("$.operation", is("still working")));
 
 		verifyDeleteServiceInstance();
 	}
@@ -639,7 +639,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		mockMvc.perform(asyncDispatch(mvcResult))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.description", containsString("still working")));
+				.andExpect(jsonPath("$.operation", is("still working")));
 
 		verifyUpdateServiceInstance();
 	}

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/async_in_progress_response.json
@@ -1,3 +1,3 @@
 {
-  "operation": "still working"
+  "operation": "task_10"
 }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/async_in_progress_response.json
@@ -1,0 +1,3 @@
+{
+  "operation": "still working"
+}

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/createAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/createAppBindingInProgress.groovy
@@ -27,9 +27,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/deleteAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/deleteAppBindingInProgress.groovy
@@ -23,9 +23,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/getAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/reactive/getAppBindingInProgress.groovy
@@ -24,7 +24,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     response {
         status NOT_FOUND()
         body([
-                "description": $(regex('.*=still working'))
+                "description": $(regex('.*=task_10'))
         ])
         headers {
             contentType('application/json')

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/async_in_progress_response.json
@@ -1,3 +1,3 @@
 {
-  "operation": "still working"
+  "operation": "task_10"
 }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/async_in_progress_response.json
@@ -1,0 +1,3 @@
+{
+  "operation": "still working"
+}

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/createAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/createAppBindingInProgress.groovy
@@ -27,9 +27,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/deleteAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/deleteAppBindingInProgress.groovy
@@ -23,9 +23,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/getAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/binding/servlet/getAppBindingInProgress.groovy
@@ -24,7 +24,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     response {
         status NOT_FOUND()
         body([
-                "description": $(regex('.*=still working'))
+                "description": $(regex('.*=task_10'))
         ])
         headers {
             contentType('application/json')

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/async_in_progress_response.json
@@ -1,3 +1,3 @@
 {
-  "operation": "still working"
+  "operation": "task_10"
 }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/async_in_progress_response.json
@@ -1,0 +1,3 @@
+{
+  "operation": "still working"
+}

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/createServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/createServiceInstanceInProgress.groovy
@@ -27,9 +27,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/deleteServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/deleteServiceInstanceInProgress.groovy
@@ -23,9 +23,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/getServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/getServiceInstanceInProgress.groovy
@@ -24,7 +24,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     response {
         status NOT_FOUND()
         body([
-                "description": $(regex('.*=still working'))
+                "description": $(regex('.*=task_10'))
         ])
         headers {
             contentType('application/json')

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/updateServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/reactive/updateServiceInstanceInProgress.groovy
@@ -27,9 +27,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/async_in_progress_response.json
@@ -1,3 +1,3 @@
 {
-  "operation": "still working"
+  "operation": "task_10"
 }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/async_in_progress_response.json
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/async_in_progress_response.json
@@ -1,0 +1,3 @@
+{
+  "operation": "still working"
+}

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/deleteServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/deleteServiceInstanceInProgress.groovy
@@ -26,9 +26,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     }
     response {
         status ACCEPTED()
-        body([
-                "description": $(regex('.*=still working'))
-        ])
+        body(file('async_in_progress_response.json'))
         headers {
             contentType('application/json')
         }

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/getServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/getServiceInstanceInProgress.groovy
@@ -27,7 +27,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     response {
         status NOT_FOUND()
         body([
-                "description": $(regex('.*=still working'))
+                "description": $(regex('.*=task_10'))
         ])
         headers {
             contentType('application/json')

--- a/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/updateServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/test/resources/contracts/instance/servlet/updateServiceInstanceInProgress.groovy
@@ -18,7 +18,7 @@ package instance.servlet
 
 org.springframework.cloud.contract.spec.Contract.make {
     request {
-        method PUT()
+        method PATCH()
         body(file("create_service_instance.json"))
         url '/v2/service_instances/service-instance-two-id'
         headers {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -40,6 +40,7 @@ import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotE
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
 import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
+import org.springframework.cloud.servicebroker.model.error.OperationInProgressMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -176,36 +177,36 @@ public abstract class ServiceBrokerExceptionHandler {
 	 * Handle a {@link ServiceBrokerCreateOperationInProgressException}
 	 *
 	 * @param ex the exception
-	 * @return an error message
+	 * @return an operation in progress message
 	 */
 	@ExceptionHandler(ServiceBrokerCreateOperationInProgressException.class)
 	@ResponseStatus(HttpStatus.ACCEPTED)
-	public ErrorMessage handleException(ServiceBrokerCreateOperationInProgressException ex) {
-		return getErrorResponse(ex);
+	public OperationInProgressMessage handleException(ServiceBrokerCreateOperationInProgressException ex) {
+		return getOperationInProgressMessage(ex);
 	}
 
 	/**
 	 * Handle a {@link ServiceBrokerUpdateOperationInProgressException}
 	 *
 	 * @param ex the exception
-	 * @return an error message
+	 * @return an operation in progress message
 	 */
 	@ExceptionHandler(ServiceBrokerUpdateOperationInProgressException.class)
 	@ResponseStatus(HttpStatus.ACCEPTED)
-	public ErrorMessage handleException(ServiceBrokerUpdateOperationInProgressException ex) {
-		return getErrorResponse(ex);
+	public OperationInProgressMessage handleException(ServiceBrokerUpdateOperationInProgressException ex) {
+		return getOperationInProgressMessage(ex);
 	}
 
 	/**
 	 * Handle a {@link ServiceBrokerDeleteOperationInProgressException}
 	 *
 	 * @param ex the exception
-	 * @return an error message
+	 * @return an operation in progress message
 	 */
 	@ExceptionHandler(ServiceBrokerDeleteOperationInProgressException.class)
 	@ResponseStatus(HttpStatus.ACCEPTED)
-	public ErrorMessage handleException(ServiceBrokerDeleteOperationInProgressException ex) {
-		return getErrorResponse(ex);
+	public OperationInProgressMessage handleException(ServiceBrokerDeleteOperationInProgressException ex) {
+		return getOperationInProgressMessage(ex);
 	}
 
 	/**
@@ -339,6 +340,17 @@ public abstract class ServiceBrokerExceptionHandler {
 	protected ErrorMessage getErrorResponse(ServiceBrokerException ex) {
 		getLog().debug(ex.getMessage(), ex);
 		return ex.getErrorMessage();
+	}
+
+	/**
+	 * Format an operation in progress message for the exception
+	 *
+	 * @param ex the exception
+	 * @return the message
+	 */
+	protected OperationInProgressMessage getOperationInProgressMessage(ServiceBrokerOperationInProgressException ex) {
+		getLog().debug(ex.getMessage(), ex);
+		return ex.getOperationInProgressMessage();
 	}
 
 	/**

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerCreateOperationInProgressException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerCreateOperationInProgressException.java
@@ -25,41 +25,24 @@ package org.springframework.cloud.servicebroker.exception;
  *
  * @author Roy Clarkson
  */
-public class ServiceBrokerCreateOperationInProgressException extends ServiceBrokerException {
+public class ServiceBrokerCreateOperationInProgressException extends ServiceBrokerOperationInProgressException {
 
 	private static final long serialVersionUID = -1248042363905670885L;
-
-	private static final String MESSAGE_PREFIX = "Service broker create operation is in progress " +
-			"for the requested service instance or binding";
 
 	/**
 	 * Construct an exception with a default message.
 	 */
 	public ServiceBrokerCreateOperationInProgressException() {
-		super(MESSAGE_PREFIX);
+		super();
 	}
 
 	/**
 	 * Construct an exception with a default message that includes the provided {@literal operation} description.
 	 *
-	 * @param operation a description of the operation in progress
+	 * @param operation an identifier representing the operation in progress
 	 */
 	public ServiceBrokerCreateOperationInProgressException(String operation) {
-		super(prependMessagePrefix(operation));
-	}
-
-	/**
-	 * Construct an exception with an error code and default message.
-	 *
-	 * @param errorCode a single word in camel case that uniquely identifies the error condition
-	 * @param operation a description of the operation in progress
-	 */
-	public ServiceBrokerCreateOperationInProgressException(String errorCode, String operation) {
-		super(errorCode, prependMessagePrefix(operation));
-	}
-
-	private static String prependMessagePrefix(String operation) {
-		return MESSAGE_PREFIX + ": operation=" + operation;
+		super(operation);
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerDeleteOperationInProgressException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerDeleteOperationInProgressException.java
@@ -25,41 +25,24 @@ package org.springframework.cloud.servicebroker.exception;
  *
  * @author Roy Clarkson
  */
-public class ServiceBrokerDeleteOperationInProgressException extends ServiceBrokerException {
+public class ServiceBrokerDeleteOperationInProgressException extends ServiceBrokerOperationInProgressException {
 
 	private static final long serialVersionUID = 8135487957024370577L;
-
-	private static final String MESSAGE_PREFIX = "Service broker delete operation is in progress " +
-			"for the requested service instance or binding";
 
 	/**
 	 * Construct an exception with a default message.
 	 */
 	public ServiceBrokerDeleteOperationInProgressException() {
-		super(MESSAGE_PREFIX);
+		super();
 	}
 
 	/**
 	 * Construct an exception with a default message that includes the provided {@literal operation} description.
 	 *
-	 * @param operation a description of the operation in progress
+	 * @param operation an identifier representing the operation in progress
 	 */
 	public ServiceBrokerDeleteOperationInProgressException(String operation) {
-		super(prependMessagePrefix(operation));
-	}
-
-	/**
-	 * Construct an exception with an error code and default message.
-	 *
-	 * @param errorCode a single word in camel case that uniquely identifies the error condition
-	 * @param operation a description of the operation in progress
-	 */
-	public ServiceBrokerDeleteOperationInProgressException(String errorCode, String operation) {
-		super(errorCode, prependMessagePrefix(operation));
-	}
-
-	private static String prependMessagePrefix(String operation) {
-		return MESSAGE_PREFIX + ": operation=" + operation;
+		super(operation);
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerOperationInProgressException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerOperationInProgressException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.servicebroker.exception;
 
+import org.springframework.cloud.servicebroker.model.error.OperationInProgressMessage;
+
 /**
  * Thrown to indicate that a request for a service instance or binding was received while asynchronous creation of the
  * service instance or binding is in progress.
@@ -32,30 +34,39 @@ public class ServiceBrokerOperationInProgressException extends ServiceBrokerExce
 	private static final String MESSAGE_PREFIX = "Service broker operation is in progress " +
 			"for the requested service instance or binding";
 
+	private final OperationInProgressMessage operationInProgressMessage;
+
 	/**
 	 * Construct an exception with a default message.
 	 */
 	public ServiceBrokerOperationInProgressException() {
 		super(MESSAGE_PREFIX);
+		this.operationInProgressMessage = new OperationInProgressMessage();
 	}
 
 	/**
 	 * Construct an exception with a default message that includes the provided {@literal operation} description.
 	 *
-	 * @param operation a description of the operation in progress
+	 * @param operation an identifier representing the operation in progress
 	 */
 	public ServiceBrokerOperationInProgressException(String operation) {
 		super(prependMessagePrefix(operation));
+		this.operationInProgressMessage = new OperationInProgressMessage(operation);
 	}
 
 	/**
 	 * Construct an exception with an error code and default message.
 	 *
 	 * @param errorCode a single word in camel case that uniquely identifies the error condition
-	 * @param operation a description of the operation in progress
+	 * @param operation an identifier representing the operation in progress
 	 */
 	public ServiceBrokerOperationInProgressException(String errorCode, String operation) {
 		super(errorCode, prependMessagePrefix(operation));
+		this.operationInProgressMessage = new OperationInProgressMessage(operation);
+	}
+
+	public OperationInProgressMessage getOperationInProgressMessage() {
+		return operationInProgressMessage;
 	}
 
 	private static String prependMessagePrefix(String operation) {

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerUpdateOperationInProgressException.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/exception/ServiceBrokerUpdateOperationInProgressException.java
@@ -25,41 +25,24 @@ package org.springframework.cloud.servicebroker.exception;
  *
  * @author Roy Clarkson
  */
-public class ServiceBrokerUpdateOperationInProgressException extends ServiceBrokerException {
+public class ServiceBrokerUpdateOperationInProgressException extends ServiceBrokerOperationInProgressException {
 
 	private static final long serialVersionUID = 3060121214729174087L;
-
-	private static final String MESSAGE_PREFIX = "Service broker update operation is in progress " +
-			"for the requested service instance";
 
 	/**
 	 * Construct an exception with a default message.
 	 */
 	public ServiceBrokerUpdateOperationInProgressException() {
-		super(MESSAGE_PREFIX);
+		super();
 	}
 
 	/**
 	 * Construct an exception with a default message that includes the provided {@literal operation} description.
 	 *
-	 * @param operation a description of the operation in progress
+	 * @param operation an identifier representing the operation in progress
 	 */
 	public ServiceBrokerUpdateOperationInProgressException(String operation) {
-		super(prependMessagePrefix(operation));
-	}
-
-	/**
-	 * Construct an exception with an error code and default message.
-	 *
-	 * @param errorCode a single word in camel case that uniquely identifies the error condition
-	 * @param operation a description of the operation in progress
-	 */
-	public ServiceBrokerUpdateOperationInProgressException(String errorCode, String operation) {
-		super(errorCode, prependMessagePrefix(operation));
-	}
-
-	private static String prependMessagePrefix(String operation) {
-		return MESSAGE_PREFIX + ": operation=" + operation;
+		super(operation);
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
@@ -44,14 +44,11 @@ public class AsyncServiceBrokerResponse {
 	 * Create a new AsyncServiceBrokerResponse
 	 *
 	 * @param async is the operation asynchronous
-	 * @param operation description of the operation being performed
+	 * @param operation an identifier representing the operation in progress
 	 * @throws IllegalArgumentException if operation length exceeds 10,000 characters
 	 */
 	protected AsyncServiceBrokerResponse(boolean async, String operation) {
-		if (StringUtils.hasLength(operation) && operation.length() > MAX_OPERATION_LENGTH) {
-			throw new IllegalArgumentException("operation strings are restricted to 10,000 characters in the response" +
-					" body");
-		}
+		validateOperationLength(operation);
 		this.async = async;
 		this.operation = operation;
 	}
@@ -110,6 +107,19 @@ public class AsyncServiceBrokerResponse {
 				"async=" + async +
 				", operation='" + operation + '\'' +
 				'}';
+	}
+
+	/**
+	 * Validate the length of the operation string to be within the 10,000 character limit
+	 *
+	 * @param operation an identifier representing the operation in progress
+	 * @throws IllegalArgumentException if the operation is longer than 10,000 characters
+	 */
+	public static void validateOperationLength(String operation) {
+		if (StringUtils.hasLength(operation) && operation.length() > MAX_OPERATION_LENGTH) {
+			throw new IllegalArgumentException("operation strings are restricted to 10,000 characters in the response" +
+					" body");
+		}
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/OperationInProgressMessage.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/OperationInProgressMessage.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.model.error;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.springframework.cloud.servicebroker.model.AsyncServiceBrokerResponse;
+
+/**
+ * Returned if a create, update, or delete operation is in progress. The operation string must match that returned for
+ * the original request.
+ *
+ * @author Roy Clarkson
+ * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/v2.15/spec.md#response-3">Open
+ * 		Service Broker API specification</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class OperationInProgressMessage {
+
+	private final String operation;
+
+	/**
+	 * Construct a message with no operation.
+	 */
+	public OperationInProgressMessage() {
+		this(null);
+	}
+
+	/**
+	 * Construct a message with the provided operation.
+	 *
+	 * @param operation an identifier representing the operation
+	 */
+	public OperationInProgressMessage(String operation) {
+		AsyncServiceBrokerResponse.validateOperationLength(operation);
+		this.operation = operation;
+	}
+
+	/**
+	 * Get the operation.
+	 *
+	 * @return the operation.
+	 */
+	public String getOperation() {
+		return this.operation;
+	}
+
+	@Override
+	public final boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof OperationInProgressMessage)) {
+			return false;
+		}
+		OperationInProgressMessage that = (OperationInProgressMessage) o;
+		return Objects.equals(operation, that.operation);
+	}
+
+	@Override
+	public final int hashCode() {
+		return Objects.hash(operation);
+	}
+
+	@Override
+	public final String toString() {
+		return "OperationInProgressMessage{" +
+				"operation='" + operation + '\'' +
+				'}';
+	}
+
+}

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandlerTest.java
@@ -140,12 +140,12 @@ abstract class ServiceBrokerExceptionHandlerTest {
 	@Test
 	void operationInProgressException() {
 		ServiceBrokerOperationInProgressException exception =
-				new ServiceBrokerOperationInProgressException("still working");
+				new ServiceBrokerOperationInProgressException("task_10");
 
 		ErrorMessage errorMessage = exceptionHandler.handleException(exception);
 
 		assertThat(errorMessage.getError()).isNull();
-		assertThat(errorMessage.getMessage()).contains("still working");
+		assertThat(errorMessage.getMessage()).contains("task_10");
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/error/OperationInProgressMessageTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/error/OperationInProgressMessageTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.servicebroker.model.error;
+
+import com.jayway.jsonpath.DocumentContext;
+import net.bytebuddy.utility.RandomString;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.servicebroker.JsonUtils;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.cloud.servicebroker.JsonPathAssert.assertThat;
+
+class OperationInProgressMessageTest {
+
+	@Test
+	void messageIsEmptyWithNoOperation() {
+		OperationInProgressMessage message = new OperationInProgressMessage();
+
+		DocumentContext json = JsonUtils.toJsonPath(message);
+
+		assertThat(json).hasNoPath("$.operation");
+	}
+
+	@Test
+	void messageHasOperation() {
+		OperationInProgressMessage message = new OperationInProgressMessage("task_10");
+
+		DocumentContext json = JsonUtils.toJsonPath(message);
+
+		assertThat(json).hasPath("$.operation").isEqualTo("task_10");
+	}
+
+	@Test
+	void operationExceedsMaxAllowedLength() {
+		assertThrows(IllegalArgumentException.class, () ->
+				new OperationInProgressMessage(RandomString.make(10_001)));
+	}
+
+	@Test
+	void operationMaxLength() {
+		new OperationInProgressMessage(RandomString.make(10_000));
+	}
+
+	@Test
+	void equalsAndHashCode() {
+		EqualsVerifier
+				.forClass(OperationInProgressMessage.class)
+				.verify();
+	}
+
+}


### PR DESCRIPTION
This commit updates the ServiceBrokerExceptionHandler to marshal an
OperationInProgressMessage response body instead of an ErrorMessage when
handling any of the following scenarios and exceptions:

Service instance provisioning ServiceBrokerCreateOperationInProgressException
Service instance updating ServiceBrokerUpdateOperationInProgressException
Service instance deleting ServiceBrokerDeleteOperationInProgressException
Service instance binding ServiceBrokerCreateOperationInProgressException
Service instance unbinding ServiceBrokerDeleteOperationInProgressException

See https://github.com/openservicebrokerapi/servicebroker/blob/v2.15/spec.md#response-3

Resolves #284