### PR TITLE
Make support for blocking and reactive stacks ever more explicit.

### DIFF
--- a/spring-cloud-open-service-broker-docs/src/docs/asciidoc/getting-started.adoc
+++ b/spring-cloud-open-service-broker-docs/src/docs/asciidoc/getting-started.adoc
@@ -5,6 +5,8 @@ Most service broker applications implement API or web UI endpoints beyond the Op
 These additional endpoints might provide information about the application, provide a dashboard UI, or provide controls over application behavior.
 Developers may implement these additional endpoints with https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html[Spring WebFlux] or https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html[Spring MVC].
 
+While spring-cloud-open-service-broker uses reactive return types in its API, both blocking web stack (such as tomcat/jetty using `spring-boot-starter-web`) or non blocking web stack (such as netty/undertow using `spring-boot-starter-webflux`) are supported. See respective acceptance tests in modules `spring-cloud-open-service-broker-acceptance-webmvc` and `spring-cloud-open-service-broker-acceptance-webflux`.
+
 NOTE: The Spring Cloud Open Service Broker starter does not include a transitive dependency on Spring WebFlux or Spring MVC.
 A Spring Boot web starter is required to activate the auto-configuration.
 

--- a/spring-cloud-open-service-broker-docs/src/docs/asciidoc/service-broker-security.adoc
+++ b/spring-cloud-open-service-broker-docs/src/docs/asciidoc/service-broker-security.adoc
@@ -11,7 +11,7 @@ by applying security to application endpoints with the path-matching pattern: `/
 
 === Example Configuration
 
-The following example implements a security configuration:
+The following example implements a security configuration in a https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html[Spring MVC] i.e blocking webstack. Similar config for a https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html[Spring WebFlux] reactive stack is necessary, see https://docs.spring.io/spring-security/site/docs/current/reference/html5/#minimal-webflux-security-configuration[Spring security webflux support]
 
 ====
 [source,java,%autofit]


### PR DESCRIPTION
During the bump of a old broker to the latest spring-cloud-open-service-broker I got trapped into switching to `spring-boot-starter-webflux` with associated migration of security config, along with incompatibilities with http client stacks (namely https://github.com/spring-cloud/spring-cloud-openfeign/issues/235)

Hoping this more explicit mention would help other users make the right decision on whether to yet upgrade to a reactive stack or stick to blocking stack for now