### PR TITLE
Return HTTP 400 Bad Request for unknown instance in last operation

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/AbstractServiceInstanceControllerIntegrationTest.java
@@ -125,6 +125,11 @@ public abstract class AbstractServiceInstanceControllerIntegrationTest extends C
 				.willReturn(Mono.error(exception));
 	}
 
+	protected void setupServiceInstanceServiceLastOperation(ServiceInstanceDoesNotExistException exception) {
+		given(serviceInstanceService.getLastOperation(any(GetLastServiceOperationRequest.class)))
+				.willReturn(Mono.error(exception));
+	}
+
 	protected void setupServiceInstanceService(UpdateServiceInstanceResponse response) {
 		given(serviceInstanceService.updateServiceInstance(any(UpdateServiceInstanceRequest.class)))
 				.willReturn(Mono.just(response));

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
@@ -53,6 +53,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException.ASYNC_REQUIRED_ERROR;
 import static org.springframework.cloud.servicebroker.exception.ServiceBrokerMaintenanceInfoConflictException.MAINTENANCE_INFO_CONFLICT_ERROR;
 import static org.springframework.cloud.servicebroker.exception.ServiceBrokerMaintenanceInfoConflictException.MAINTENANCE_INFO_CONFLICT_MESSAGE;
@@ -785,6 +786,20 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.expectBody()
 				.jsonPath("$.state").isEqualTo(OperationState.SUCCEEDED.toString())
 				.jsonPath("$.description").isEqualTo("all gone");
+	}
+
+	@Test
+	void lastOperationWithUnknownInstanceBadRequest() {
+		setupServiceInstanceServiceLastOperation(new ServiceInstanceDoesNotExistException("nonexistent-instance-id"));
+
+		client.get().uri(buildLastOperationUrl())
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().is4xxClientError()
+				.expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+				.expectBody()
+				.jsonPath("$.state").doesNotExist()
+				.jsonPath("$.description").value(containsString("The requested Service Instance does not exist"));
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -862,6 +862,21 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
+	void lastOperationWithUnknownInstanceBadRequest() throws Exception {
+		setupServiceInstanceServiceLastOperation(new ServiceInstanceDoesNotExistException("nonexistent-instance-id"));
+
+		MvcResult mvcResult = mockMvc.perform(get(buildLastOperationUrl()))
+				.andExpect(request().asyncStarted())
+				.andReturn();
+
+		mockMvc.perform(asyncDispatch(mvcResult))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.state").doesNotExist())
+				.andExpect(jsonPath("$.description",
+						containsString("The requested Service Instance does not exist")));
+	}
+
+	@Test
 	void lastOperationHasFailedStatus() throws Exception {
 		setupServiceInstanceService(GetLastServiceOperationResponse.builder()
 				.operationState(OperationState.FAILED)

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerResponseCodeTest.java
@@ -314,6 +314,20 @@ class ServiceInstanceControllerResponseCodeTest {
 	}
 
 	@Test
+	void getLastOperationWithUnknownInstanceBadRequest() {
+		given(serviceInstanceService.getLastOperation(any(GetLastServiceOperationRequest.class)))
+				.willReturn(Mono.error(new ServiceInstanceDoesNotExistException("instance never existed")));
+
+		ResponseEntity<GetLastServiceOperationResponse> responseEntity = controller
+				.getServiceInstanceLastOperation(pathVariables, null, "service-definition-id",
+						"service-definition-plan-id", null, null, null, null)
+				.block();
+
+		assertThat(responseEntity).isNotNull();
+		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+	}
+
+	@Test
 	void getLastOperationWithFailedResponseGivesExpectedStatus() {
 		validateGetLastOperationWithResponseStatus(GetLastServiceOperationResponse.builder()
 				.operationState(OperationState.FAILED)


### PR DESCRIPTION
v2.15 of the OSB API spec is a little unclear about how to handle the
scenario where a request is made for the last operation of an instance id
that does not exist and never existed. It does specify a 400 Bad Request
for "malformed or missing mandatory data". In this case an unknown instance
id is provided, so it's the best option for response code.

The spec is improved in v2.16. There, it adds a 404 Not Found for this
scenario. We'll change this when we move to the newer spec.

Resolves #306