### PR TITLE
Return a 400 for a request with an empty body or mismatched content type

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
@@ -414,6 +414,56 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
+	void createServiceInstanceWithEmptyBodyFails() throws Exception {
+		final String body = "";
+
+		client.put().uri(buildCreateUpdateUrl())
+				.contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(body)
+				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
+				.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.description").isNotEmpty()
+				.consumeWith(result -> assertDescriptionContains(result, "Failed to read HTTP message"));
+	}
+
+	@Test
+	void createServiceInstanceWithEmptyBodyAndNoContentTypeFails() throws Exception {
+		final String body = "";
+
+		client.put().uri(buildCreateUpdateUrl())
+				.bodyValue(body)
+				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
+				.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.description").isNotEmpty()
+				.consumeWith(result -> assertDescriptionContains(result, "Content type 'text/plain;charset=UTF-8' not supported"));
+	}
+
+	@Test
+	void createServiceInstanceWithEmptyBodyAndMismatchedContentTypeFails() throws Exception {
+		final String body = "";
+
+		client.put().uri(buildCreateUpdateUrl())
+				.contentType(MediaType.TEXT_PLAIN)
+				.bodyValue(body)
+				.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
+				.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isBadRequest()
+				.expectBody()
+				.jsonPath("$.description").isNotEmpty()
+				.consumeWith(result -> assertDescriptionContains(result, "Content type 'text/plain' not supported"));
+	}
+
+	@Test
 	void getServiceInstanceSucceeds() throws Exception {
 		setupServiceInstanceService(GetServiceInstanceResponse.builder()
 				.build());

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -461,6 +461,53 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
+	void createServiceInstanceWithEmptyBodyFails() throws Exception {
+		final String body = "";
+
+		mockMvc.perform(put(buildCreateUpdateUrl())
+						.content(body)
+						.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
+						.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
+						.contentType(MediaType.APPLICATION_JSON)
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.description", containsString("Required request body is missing")))
+				.andExpect(request().asyncNotStarted())
+				.andReturn();
+	}
+
+	@Test
+	void createServiceInstanceWithEmptyBodyAndNoContentTypeFails() throws Exception {
+		final String body = "";
+
+		mockMvc.perform(put(buildCreateUpdateUrl())
+						.content(body)
+						.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
+						.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.description", containsString("Required request body is missing")))
+				.andExpect(request().asyncNotStarted())
+				.andReturn();
+	}
+
+	@Test
+	void createServiceInstanceWithEmptyBodyAndMismatchedContentTypeFails() throws Exception {
+		final String body = "";
+
+		mockMvc.perform(put(buildCreateUpdateUrl())
+						.content(body)
+						.header(API_INFO_LOCATION_HEADER, API_INFO_LOCATION)
+						.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
+						.contentType(MediaType.TEXT_PLAIN)
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.description", containsString("Content type 'text/plain' not supported")))
+				.andExpect(request().asyncNotStarted())
+				.andReturn();
+	}
+
+	@Test
 	void getServiceInstanceSucceeds() throws Exception {
 		setupServiceInstanceService(GetServiceInstanceResponse.builder()
 				.build());

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerWebFluxExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerWebFluxExceptionHandler.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.server.ServerWebInputException;
+import org.springframework.web.server.UnsupportedMediaTypeStatusException;
 
 /**
  * Exception handling logic shared by WebFlux Controllers.
@@ -72,6 +73,19 @@ public class ServiceBrokerWebFluxExceptionHandler extends ServiceBrokerException
 	public ErrorMessage handleException(ServerWebInputException ex) {
 		LOG.error(UNPROCESSABLE_REQUEST, ex);
 		return getErrorResponse(ex.getMessage());
+	}
+
+	/**
+	 * Handle a {@link UnsupportedMediaTypeStatusException}
+	 *
+	 * @param ex the exception
+	 * @return an error message
+	 */
+	@ExceptionHandler(UnsupportedMediaTypeStatusException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorMessage handleException(UnsupportedMediaTypeStatusException ex) {
+		getLog().error(UNPROCESSABLE_REQUEST, ex);
+		return getErrorResponse(ex);
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerWebMvcExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerWebMvcExceptionHandler.java
@@ -24,6 +24,8 @@ import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -70,6 +72,32 @@ public class ServiceBrokerWebMvcExceptionHandler extends ServiceBrokerExceptionH
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ErrorMessage handleException(MissingServletRequestParameterException ex) {
+		LOG.error(UNPROCESSABLE_REQUEST, ex);
+		return getErrorResponse(ex.getMessage());
+	}
+
+	/**
+	 * Handle a {@link HttpMediaTypeNotSupportedException}
+	 *
+	 * @param ex the exception
+	 * @return an error message
+	 */
+	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorMessage handleException(HttpMediaTypeNotSupportedException ex) {
+		LOG.error(UNPROCESSABLE_REQUEST, ex);
+		return getErrorResponse(ex.getMessage());
+	}
+
+	/**
+	 * Handle a {@link HttpMessageNotReadableException}
+	 *
+	 * @param ex the exception
+	 * @return an error message
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorMessage handleException(HttpMessageNotReadableException ex) {
 		LOG.error(UNPROCESSABLE_REQUEST, ex);
 		return getErrorResponse(ex.getMessage());
 	}


### PR DESCRIPTION
The OSB spec states "If a Service Broker rejects a request due to a
mismatched Content-Type or the body is unprocessable it SHOULD respond with
400 Bad Request"

Previously, a request with an empty body or a mismatched content type would
result in exceptions being thrown that would be handled by the generic
exception handler in Spring Cloud Open Service Broker, which would then
return a 500 response.

see https://github.com/openservicebrokerapi/servicebroker/blob/v2.16/spec.md#content-type

closes #329