### PR TITLE
Possibility to extend broker responses

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
@@ -277,7 +277,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -305,7 +305,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceDefinitionId, serviceInstanceId, planId, bindingId,
 				appGuid, bindResource, serviceDefinition, plan);
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
@@ -184,7 +184,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -210,7 +210,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceInstanceId, bindingId,
 				serviceDefinitionId, planId, serviceDefinition, plan);
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequest.java
@@ -148,7 +148,7 @@ public class GetLastServiceBindingOperationRequest extends ServiceBrokerRequest 
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -173,7 +173,7 @@ public class GetLastServiceBindingOperationRequest extends ServiceBrokerRequest 
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceInstanceId, bindingId, serviceDefinitionId, planId, operation);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
@@ -104,7 +104,7 @@ public class GetLastServiceBindingOperationResponse {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -112,13 +112,24 @@ public class GetLastServiceBindingOperationResponse {
 			return false;
 		}
 		GetLastServiceBindingOperationResponse that = (GetLastServiceBindingOperationResponse) o;
-		return deleteOperation == that.deleteOperation &&
+		return that.canEqual(this) &&
+				deleteOperation == that.deleteOperation &&
 				state == that.state &&
 				Objects.equals(description, that.description);
 	}
 
+	/**
+	 * Is another object type compatible with this object
+	 *
+	 * @param other the other object
+	 * @return true of compatible
+	 */
+	public boolean canEqual(Object other) {
+		return other instanceof GetLastServiceBindingOperationResponse;
+	}
+
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(state, description, deleteOperation);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequest.java
@@ -129,7 +129,7 @@ public class GetServiceInstanceBindingRequest extends ServiceBrokerRequest {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -153,7 +153,7 @@ public class GetServiceInstanceBindingRequest extends ServiceBrokerRequest {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceInstanceId, bindingId, serviceDefinitionId, planId);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Catalog.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Catalog.java
@@ -69,7 +69,7 @@ public class Catalog {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -77,11 +77,21 @@ public class Catalog {
 			return false;
 		}
 		Catalog catalog = (Catalog) o;
-		return Objects.equals(serviceDefinitions, catalog.serviceDefinitions);
+		return catalog.canEqual(this) && Objects.equals(serviceDefinitions, catalog.serviceDefinitions);
+	}
+
+	/**
+	 * Is another object type compatible with this object
+	 *
+	 * @param other the other object
+	 * @return true of compatible
+	 */
+	public boolean canEqual(Object other) {
+		return other instanceof Catalog;
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(serviceDefinitions);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinition.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinition.java
@@ -251,7 +251,7 @@ public class ServiceDefinition {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -259,7 +259,8 @@ public class ServiceDefinition {
 			return false;
 		}
 		ServiceDefinition that = (ServiceDefinition) o;
-		return bindable == that.bindable &&
+		return that.canEqual(this) &&
+				bindable == that.bindable &&
 				Objects.equals(planUpdateable, that.planUpdateable) &&
 				Objects.equals(instancesRetrievable, that.instancesRetrievable) &&
 				Objects.equals(bindingsRetrievable, that.bindingsRetrievable) &&
@@ -274,8 +275,18 @@ public class ServiceDefinition {
 				Objects.equals(dashboardClient, that.dashboardClient);
 	}
 
+	/**
+	 * Is another object type compatible with this object
+	 *
+	 * @param other the other object
+	 * @return true of compatible
+	 */
+	public boolean canEqual(Object other) {
+		return other instanceof ServiceDefinition;
+	}
+
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(id, name, description, bindable, planUpdateable,
 				instancesRetrievable, bindingsRetrievable, allowContextUpdates,
 				plans, tags, metadata, requires, dashboardClient);

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
@@ -324,7 +324,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 * {@inheritDoc}
 	 */
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -352,7 +352,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceDefinitionId, planId,
 				organizationGuid, spaceGuid, serviceInstanceId, serviceDefinition, plan, maintenanceInfo);
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
@@ -110,7 +110,7 @@ public class CreateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -133,7 +133,7 @@ public class CreateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), dashboardUrl, instanceExisted, metadata);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
@@ -168,7 +168,7 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -193,7 +193,7 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceInstanceId,
 				serviceDefinitionId, planId, serviceDefinition, plan);
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequest.java
@@ -130,7 +130,7 @@ public class GetLastServiceOperationRequest extends ServiceBrokerRequest {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -154,7 +154,7 @@ public class GetLastServiceOperationRequest extends ServiceBrokerRequest {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceInstanceId, serviceDefinitionId, planId, operation);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
@@ -146,8 +146,18 @@ public class GetLastServiceOperationResponse {
 		return new GetLastServiceOperationResponseBuilder();
 	}
 
+	/**
+	 * Is another object type compatible with this object
+	 *
+	 * @param other the other object
+	 * @return true of compatible
+	 */
+	public boolean canEqual(Object other) {
+		return other instanceof GetLastServiceOperationResponse;
+	}
+
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -155,7 +165,8 @@ public class GetLastServiceOperationResponse {
 			return false;
 		}
 		GetLastServiceOperationResponse that = (GetLastServiceOperationResponse) o;
-		return state == that.state &&
+		return that.canEqual(this) &&
+				state == that.state &&
 				Objects.equals(description, that.description) &&
 				Objects.equals(instanceUsable, that.instanceUsable) &&
 				Objects.equals(updateRepeatable, that.updateRepeatable) &&
@@ -163,7 +174,7 @@ public class GetLastServiceOperationResponse {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(state, description, instanceUsable, updateRepeatable, deleteOperation);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequest.java
@@ -111,7 +111,7 @@ public class GetServiceInstanceRequest extends ServiceBrokerRequest {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -134,7 +134,7 @@ public class GetServiceInstanceRequest extends ServiceBrokerRequest {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceInstanceId, serviceDefinitionId, planId);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponse.java
@@ -120,7 +120,7 @@ public class GetServiceInstanceResponse {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -146,7 +146,7 @@ public class GetServiceInstanceResponse {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(serviceDefinitionId, planId, dashboardUrl, parameters);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
@@ -240,7 +240,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -267,7 +267,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), serviceDefinitionId, planId, previousValues,
 				serviceInstanceId, serviceDefinition, plan, maintenanceInfo);
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponse.java
@@ -93,7 +93,7 @@ public class UpdateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	}
 
 	@Override
-	public final boolean equals(Object o) {
+	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
 		}
@@ -115,7 +115,7 @@ public class UpdateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	}
 
 	@Override
-	public final int hashCode() {
+	public int hashCode() {
 		return Objects.hash(super.hashCode(), dashboardUrl, metadata);
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/CatalogService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/CatalogService.java
@@ -33,7 +33,7 @@ public interface CatalogService {
 	 *
 	 * @return the catalog of services
 	 */
-	Mono<Catalog> getCatalog();
+	<T extends Catalog> Mono<T> getCatalog();
 
 	/**
 	 * Get a service definition from the catalog by ID.
@@ -41,6 +41,6 @@ public interface CatalogService {
 	 * @param serviceId The ID of the service definition in the catalog
 	 * @return the service definition, or null if it doesn't exist
 	 */
-	Mono<ServiceDefinition> getServiceDefinition(String serviceId);
+	<T extends ServiceDefinition> Mono<T> getServiceDefinition(String serviceId);
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceBindingService.java
@@ -58,7 +58,7 @@ public interface ServiceInstanceBindingService {
 	 * @throws ServiceBrokerCreateOperationInProgressException if a an operation is in progress for the service
 	 * 		binding
 	 */
-	default Mono<CreateServiceInstanceBindingResponse> createServiceInstanceBinding(
+	default <T extends CreateServiceInstanceBindingResponse> Mono<T> createServiceInstanceBinding(
 			CreateServiceInstanceBindingRequest request) {
 		return Mono.error(new UnsupportedOperationException(
 				"This service broker does not support creating service bindings."));
@@ -74,7 +74,7 @@ public interface ServiceInstanceBindingService {
 	 * @throws ServiceInstanceBindingDoesNotExistException if a binding with the given ID is not known to the broker
 	 * @throws ServiceBrokerOperationInProgressException if a an operation is in progress for the service binding
 	 */
-	default Mono<GetServiceInstanceBindingResponse> getServiceInstanceBinding(
+	default <T extends GetServiceInstanceBindingResponse> Mono<T> getServiceInstanceBinding(
 			GetServiceInstanceBindingRequest request) {
 		return Mono.error(new UnsupportedOperationException(
 				"This service broker does not support retrieving service bindings. " +
@@ -91,7 +91,7 @@ public interface ServiceInstanceBindingService {
 	 * 		broker
 	 * @throws ServiceInstanceBindingDoesNotExistException if a binding with the given ID is not known to the broker
 	 */
-	default Mono<GetLastServiceBindingOperationResponse> getLastOperation(
+	default <T extends GetLastServiceBindingOperationResponse> Mono<T> getLastOperation(
 			GetLastServiceBindingOperationRequest request) {
 		return Mono
 				.error(new UnsupportedOperationException("This service broker does not support getting the status of " +
@@ -112,7 +112,7 @@ public interface ServiceInstanceBindingService {
 	 * 		binding
 	 * @throws ServiceBrokerAsyncRequiredException if the broker requires asynchronous processing of the request
 	 */
-	default Mono<DeleteServiceInstanceBindingResponse> deleteServiceInstanceBinding(
+	default <T extends DeleteServiceInstanceBindingResponse> Mono<T> deleteServiceInstanceBinding(
 			DeleteServiceInstanceBindingRequest request) {
 		return Mono.error(new UnsupportedOperationException(
 				"This service broker does not support deleting service bindings."));

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/ServiceInstanceService.java
@@ -61,7 +61,7 @@ public interface ServiceInstanceService {
 	 * @throws ServiceBrokerCreateOperationInProgressException if a an operation is in progress for the service
 	 * 		instance
 	 */
-	Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request);
+	<T extends CreateServiceInstanceResponse> Mono<T> createServiceInstance(CreateServiceInstanceRequest request);
 
 	/**
 	 * Get the details of a service instance.
@@ -74,7 +74,7 @@ public interface ServiceInstanceService {
 	 * @throws ServiceBrokerConcurrencyException if a service instance is being updated and therefore cannot be
 	 * 		fetched
 	 */
-	default Mono<GetServiceInstanceResponse> getServiceInstance(GetServiceInstanceRequest request) {
+	default <T extends GetServiceInstanceResponse> Mono<T> getServiceInstance(GetServiceInstanceRequest request) {
 		return Mono.error(new UnsupportedOperationException("This service broker does not support retrieving service " +
 				"instances. The service broker should set 'instances_retrievable:false' in the service catalog, or " +
 				"provide an implementation of the fetch instance API."));
@@ -88,7 +88,8 @@ public interface ServiceInstanceService {
 	 * @throws ServiceInstanceDoesNotExistException if a service instance with the given ID is not known to the
 	 * 		broker
 	 */
-	default Mono<GetLastServiceOperationResponse> getLastOperation(GetLastServiceOperationRequest request) {
+	default <T extends GetLastServiceOperationResponse> Mono<T> getLastOperation(
+			GetLastServiceOperationRequest request) {
 		return Mono.error(new UnsupportedOperationException("This service broker does not support getting the status " +
 				"of an asynchronous operation. If the service broker returns '202 Accepted' in response to a " +
 				"provision, update, or deprovision request, it must also provide an implementation of the get last " +
@@ -105,7 +106,7 @@ public interface ServiceInstanceService {
 	 * @throws ServiceBrokerAsyncRequiredException if the broker requires asynchronous processing of the request
 	 * @throws ServiceBrokerDeleteOperationInProgressException if an operation is in progress for the service instance
 	 */
-	Mono<DeleteServiceInstanceResponse> deleteServiceInstance(DeleteServiceInstanceRequest request);
+	<T extends DeleteServiceInstanceResponse> Mono<T> deleteServiceInstance(DeleteServiceInstanceRequest request);
 
 	/**
 	 * Update a service instance.
@@ -120,7 +121,8 @@ public interface ServiceInstanceService {
 	 * @throws ServiceBrokerInvalidParametersException if any parameters passed in the request are invalid
 	 * @throws ServiceBrokerUpdateOperationInProgressException if an operation is in progress for the service instance
 	 */
-	default Mono<UpdateServiceInstanceResponse> updateServiceInstance(UpdateServiceInstanceRequest request) {
+	default <T extends UpdateServiceInstanceResponse> Mono<T> updateServiceInstance(
+			UpdateServiceInstanceRequest request) {
 		return Mono.error(new UnsupportedOperationException("This service broker does not support updating service " +
 				"instances. The service broker should set 'plan_updateable:false' in the service catalog, or " +
 				"provide an implementation of the update instance API."));

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequestTest.java
@@ -247,6 +247,7 @@ class CreateServiceInstanceBindingRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequestTest.java
@@ -119,6 +119,7 @@ class DeleteServiceInstanceBindingRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationRequestTest.java
@@ -81,6 +81,7 @@ class GetLastServiceBindingOperationRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponseTest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.servicebroker.model.binding;
 
 import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -117,6 +118,7 @@ class GetLastServiceBindingOperationResponseTest {
 	void equalsAndHashCode() {
 		EqualsVerifier
 				.forClass(GetLastServiceBindingOperationResponse.class)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingRequestTest.java
@@ -77,6 +77,7 @@ class GetServiceInstanceBindingRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/CatalogTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/CatalogTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -111,7 +112,7 @@ class CatalogTest {
 
 	@Test
 	void equalsAndHashCode() {
-		EqualsVerifier.forClass(Catalog.class).verify();
+		EqualsVerifier.forClass(Catalog.class).suppress(Warning.STRICT_INHERITANCE).verify();
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinitionTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/catalog/ServiceDefinitionTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -149,6 +150,7 @@ class ServiceDefinitionTest {
 	void equalsAndHashCode() {
 		EqualsVerifier
 				.forClass(ServiceDefinition.class)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequestTest.java
@@ -204,6 +204,7 @@ class CreateServiceInstanceRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponseTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.jayway.jsonpath.DocumentContext;
 import net.bytebuddy.utility.RandomString;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.Test;
 
@@ -97,6 +98,7 @@ class CreateServiceInstanceResponseTest {
 		EqualsVerifier
 				.forClass(CreateServiceInstanceResponse.class)
 				.withRedefinedSuperclass()
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequestTest.java
@@ -113,6 +113,7 @@ class DeleteServiceInstanceRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationRequestTest.java
@@ -76,6 +76,7 @@ class GetLastServiceOperationRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponseTest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.servicebroker.model.instance;
 
 import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -136,6 +137,7 @@ class GetLastServiceOperationResponseTest {
 	void equalsAndHashCode() {
 		EqualsVerifier
 				.forClass(GetLastServiceOperationResponse.class)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceRequestTest.java
@@ -73,6 +73,7 @@ class GetServiceInstanceRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponseTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.servicebroker.JsonUtils;
@@ -103,6 +104,7 @@ class GetServiceInstanceResponseTest {
 	void equalsAndHashCode() {
 		EqualsVerifier
 				.forClass(GetServiceInstanceResponse.class)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequestTest.java
@@ -145,6 +145,7 @@ class UpdateServiceInstanceRequestTest {
 				.withRedefinedSuperclass()
 				.suppress(Warning.NONFINAL_FIELDS)
 				.suppress(Warning.TRANSIENT_FIELDS)
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponseTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponseTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.jayway.jsonpath.DocumentContext;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.Test;
 
@@ -88,6 +89,7 @@ class UpdateServiceInstanceResponseTest {
 		EqualsVerifier
 				.forClass(UpdateServiceInstanceResponse.class)
 				.withRedefinedSuperclass()
+				.suppress(Warning.STRICT_INHERITANCE)
 				.verify();
 	}
 


### PR DESCRIPTION
In some cases we need to extend OSB specification and add extra fields to responses from service broker. For example it is not possible right now write something like this:
```java
public class MyCreateServiceInstanceResponse extends CreateServiceInstanceResponse {

    private final String myCustomField2;

    ...
}
```
and after that use this reponse in ServiceInstanceService:
```java
public class MyServiceInstanceService implements ServiceInstanceService {
...
    @Override
    public Mono<MyCreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
...
}
```
Java compiler throw exception like this in that case:
```
java: my.package.MyServiceInstanceService is not abstract and does not override abstract method createServiceInstance(org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest) in org.springframework.cloud.servicebroker.service.ServiceInstanceService
```

This changes are intended to allow this to be done.