### PR TITLE
Support ETag and If-Modified-Since headers to enable catalog caching

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilterIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ApiVersionWebFilterIntegrationTest.java
@@ -37,6 +37,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,9 +85,7 @@ class ApiVersionWebFilterIntegrationTest {
 
 	@Test
 	void matchingHeaderSent() {
-		given(catalogService.getCatalog())
-				.willReturn(Mono.just(Catalog.builder().build()));
-
+		setUpCatalogMocks();
 		mockWithExpectedVersion().get().uri(CATALOG_PATH)
 				.header(BrokerApiVersion.DEFAULT_API_VERSION_HEADER, "expected-version")
 				.accept(MediaType.APPLICATION_JSON)
@@ -96,9 +95,7 @@ class ApiVersionWebFilterIntegrationTest {
 
 	@Test
 	void anyHeaderNotSent() {
-		given(catalogService.getCatalog())
-				.willReturn(Mono.just(Catalog.builder().build()));
-
+		setUpCatalogMocks();
 		mockWithDefaultVersion().get().uri(CATALOG_PATH)
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
@@ -107,14 +104,20 @@ class ApiVersionWebFilterIntegrationTest {
 
 	@Test
 	void anyHeaderSent() {
-		given(catalogService.getCatalog())
-				.willReturn(Mono.just(Catalog.builder().build()));
-
+		setUpCatalogMocks();
 		mockWithDefaultVersion().get().uri(CATALOG_PATH)
 				.header(BrokerApiVersion.DEFAULT_API_VERSION_HEADER, "ignored-version")
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
 				.expectStatus().isOk();
+	}
+
+	private void setUpCatalogMocks() {
+		given(catalogService.getCatalog())
+				.willReturn(Mono.just(Catalog.builder().build()));
+
+		given(this.catalogService.getResponseEntityCatalog(any()))
+				.willReturn(Mono.empty());
 	}
 
 	private WebTestClient mockWithDefaultVersion() {

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptorIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/RequestIdentityInterceptorIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
@@ -54,14 +55,18 @@ class RequestIdentityInterceptorIntegrationTest {
 		this.mvc = MockMvcBuilders.standaloneSetup(controller)
 				.addInterceptors(new RequestIdentityInterceptor())
 				.build();
+
 		given(catalogService.getCatalog())
 				.willReturn(Mono.just(Catalog.builder().build()));
+
+		given(this.catalogService.getResponseEntityCatalog(any()))
+				.willReturn(Mono.empty());
 	}
 
 	@Test
 	void noHeaderSent() throws Exception {
 		mvc.perform(get(CATALOG_PATH)
-				.accept(MediaType.APPLICATION_JSON))
+						.accept(MediaType.APPLICATION_JSON))
 				.andExpect(result -> assertThat(
 						result.getResponse().getHeaderValue(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER)).isNull())
 				.andReturn();
@@ -70,8 +75,8 @@ class RequestIdentityInterceptorIntegrationTest {
 	@Test
 	void headerSent() throws Exception {
 		mvc.perform(get(CATALOG_PATH)
-				.header(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, "request-id")
-				.accept(MediaType.APPLICATION_JSON))
+						.header(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER, "request-id")
+						.accept(MediaType.APPLICATION_JSON))
 				.andExpect(result -> assertThat(
 						result.getResponse().getHeaderValue(ServiceBrokerRequest.REQUEST_IDENTITY_HEADER))
 						.isEqualTo("request-id"))

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
@@ -23,13 +23,17 @@ import reactor.core.publisher.Mono;
 import org.springframework.cloud.servicebroker.annotation.ServiceBrokerRestController;
 import org.springframework.cloud.servicebroker.model.catalog.Catalog;
 import org.springframework.cloud.servicebroker.service.CatalogService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 /**
  * Provide endpoints for the catalog API.
  *
  * @author sgreenberg@pivotal.io
  * @author Scott Frederick
+ * @author Roy Clarkson
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#catalog-management">Open
  * 		Service Broker API specification</a>
  */
@@ -53,14 +57,18 @@ public class CatalogController extends BaseController {
 	 * @return the catalog
 	 */
 	@GetMapping({"/v2/catalog", "{platformInstanceId}/v2/catalog"})
-	public Mono<Catalog> getCatalog() {
-		return catalogService.getCatalog()
-				.doOnRequest(v -> LOG.info("Retrieving catalog"))
-				.doOnSuccess(catalog -> {
-					LOG.info("Success retrieving catalog");
-					LOG.debug("catalog={}", catalog);
-				})
-				.doOnError(e -> LOG.error("Error retrieving catalog. error=" + e.getMessage(), e));
+	public Mono<ResponseEntity<Catalog>> getCatalog(@RequestHeader HttpHeaders httpHeaders) {
+		return catalogService.getResponseEntityCatalog(httpHeaders)
+				.switchIfEmpty(catalogService.getCatalog()
+						.doOnRequest(v -> LOG.info("Retrieving catalog"))
+						.doOnSuccess(catalog -> {
+							LOG.info("Success retrieving catalog");
+							LOG.debug("catalog={}", catalog);
+						})
+						.doOnError(e -> LOG.error("Error retrieving catalog. error=" + e.getMessage(), e))
+						.flatMap(catalog -> Mono.just(ResponseEntity
+								.ok()
+								.body(catalog))));
 	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/CatalogService.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/service/CatalogService.java
@@ -18,13 +18,17 @@ package org.springframework.cloud.servicebroker.service;
 
 import reactor.core.publisher.Mono;
 
+import org.springframework.cloud.servicebroker.controller.CatalogController;
 import org.springframework.cloud.servicebroker.model.catalog.Catalog;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 
 /**
  * This interface is implemented by service brokers to process requests to retrieve the service catalog.
  *
  * @author sgreenberg@pivotal.io
+ * @author Roy Clarkson
  */
 public interface CatalogService {
 
@@ -42,5 +46,17 @@ public interface CatalogService {
 	 * @return the service definition, or null if it doesn't exist
 	 */
 	Mono<ServiceDefinition> getServiceDefinition(String serviceId);
+
+	/**
+	 * Return the {@link ResponseEntity} with catalog of services provided by the service broker. Implementing
+	 * service brokers may use this method to manage ETag responses and caching of the catalog. This ResponseEntity
+	 * returned by this method is directly returned in the {@link CatalogController#getCatalog(HttpHeaders)} method.
+	 *
+	 * @param httpHeaders the HttpHeaders from the request
+	 * @return the ResponseEntity with catalog or an appropriate ETag response
+	 */
+	default Mono<ResponseEntity<Catalog>> getResponseEntityCatalog(HttpHeaders httpHeaders) {
+		return Mono.empty();
+	}
 
 }

--- a/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/CatalogControllerTest.java
+++ b/spring-cloud-open-service-broker-core/src/test/java/org/springframework/cloud/servicebroker/controller/CatalogControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.servicebroker.model.catalog.Catalog;
 import org.springframework.cloud.servicebroker.service.CatalogService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -42,11 +43,17 @@ class CatalogControllerTest {
 	}
 
 	@Test
-	void catalogIsReturned() {
+	void catalogIsReturned() throws Exception {
 		Catalog expectedCatalog = Catalog.builder().build();
-		given(catalogService.getCatalog()).willReturn(Mono.just(expectedCatalog));
+
+		given(catalogService.getCatalog())
+				.willReturn(Mono.just(expectedCatalog));
+
+		given(this.catalogService.getResponseEntityCatalog(any()))
+				.willReturn(Mono.empty());
+
 		CatalogController controller = new CatalogController(catalogService);
-		Catalog actualCatalog = controller.getCatalog().block();
+		Catalog actualCatalog = controller.getCatalog(null).block().getBody();
 		assertThat(actualCatalog).isEqualTo(expectedCatalog);
 	}
 


### PR DESCRIPTION
This commit adds a new interface method to CatalogService that allows the implementing Service Broker to set the ETag header in the reponse, and inspect the If-Modified-Since and If-None-Match headers in the incoming request, in order to determine if the catalog is out of date when responding.

Closes #372