### PR TITLE
Include service instance id and binding id in INFO level log messages

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.servicebroker.autoconfigure.web.AbstractServiceInstanceBindingControllerIntegrationTest;
 import org.springframework.cloud.servicebroker.controller.ServiceBrokerWebFluxExceptionHandler;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerCreateOperationInProgressException;
@@ -53,6 +55,7 @@ import static org.springframework.cloud.servicebroker.model.ServiceBrokerRequest
 import static org.springframework.cloud.servicebroker.model.ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceInstanceBindingControllerIntegrationTest {
 
 	private WebTestClient client;
@@ -65,7 +68,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void createBindingToAppWithoutAsyncAndHeadersSucceeds() throws Exception {
+	void createBindingToAppWithoutAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceBindingService(CreateServiceInstanceAppBindingResponse.builder()
@@ -83,6 +86,11 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		CreateServiceInstanceBindingRequest actualRequest = verifyCreateBinding();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Creating service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Creating service instance binding succeeded: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test
@@ -343,7 +351,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void getBindingToAppSucceeds() throws Exception {
+	void getBindingToAppSucceeds(CapturedOutput output) throws Exception {
 		setupServiceInstanceBindingService(GetServiceInstanceAppBindingResponse.builder()
 				.build());
 
@@ -356,6 +364,11 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		GetServiceInstanceBindingRequest actualRequest = verifyGetBinding();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Getting service instance binding succeeded: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test
@@ -402,7 +415,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void deleteBindingWithoutAsyncAndHeadersSucceeds() throws Exception {
+	void deleteBindingWithoutAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceBindingService(DeleteServiceInstanceBindingResponse.builder()
@@ -424,6 +437,11 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 		DeleteServiceInstanceBindingRequest actualRequest = verifyDeleteBinding();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(false);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Deleting service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Deleting service instance binding succeeded: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test
@@ -570,7 +588,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void lastOperationHasSucceededStatus() throws Exception {
+	void lastOperationHasSucceededStatus(CapturedOutput output) throws Exception {
 		setupServiceInstanceBindingService(GetLastServiceBindingOperationResponse.builder()
 				.operationState(OperationState.SUCCEEDED)
 				.description("all good")
@@ -591,6 +609,11 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		GetLastServiceBindingOperationRequest actualRequest = verifyLastOperation();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting last operation for service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Getting last operation for service instance binding succeeded: " +
+				"serviceInstanceId=" + SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.servicebroker.autoconfigure.web.AbstractServiceInstanceControllerIntegrationTest;
 import org.springframework.cloud.servicebroker.controller.ServiceBrokerWebFluxExceptionHandler;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
@@ -61,6 +63,7 @@ import static org.springframework.cloud.servicebroker.model.ServiceBrokerRequest
 import static org.springframework.cloud.servicebroker.model.ServiceBrokerRequest.ORIGINATING_IDENTITY_HEADER;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceControllerIntegrationTest {
 
 	private WebTestClient client;
@@ -73,7 +76,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void createServiceInstanceWithAsyncAndHeadersSucceeds() throws Exception {
+	void createServiceInstanceWithAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceService(CreateServiceInstanceResponse.builder()
@@ -92,6 +95,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 		CreateServiceInstanceRequest actualRequest = verifyCreateServiceInstance();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(true);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Creating service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Creating service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -464,7 +470,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void getServiceInstanceSucceeds() throws Exception {
+	void getServiceInstanceSucceeds(CapturedOutput output) throws Exception {
 		setupServiceInstanceService(GetServiceInstanceResponse.builder()
 				.build());
 
@@ -477,6 +483,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		GetServiceInstanceRequest actualRequest = verifyGetServiceInstance();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Getting service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -510,7 +519,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void deleteServiceInstanceWithAsyncAndHeadersSucceeds() throws Exception {
+	void deleteServiceInstanceWithAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceService(DeleteServiceInstanceResponse.builder()
@@ -530,6 +539,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 		DeleteServiceInstanceRequest actualRequest = verifyDeleteServiceInstance();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(true);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Deleting service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Deleting service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -632,7 +644,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void updateServiceInstanceWithAsyncAndHeadersSucceeds() throws Exception {
+	void updateServiceInstanceWithAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceService(UpdateServiceInstanceResponse.builder()
@@ -656,6 +668,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 		UpdateServiceInstanceRequest actualRequest = verifyUpdateServiceInstance();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(true);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Updating service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Updating service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -818,7 +833,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void lastOperationHasSucceededStatus() throws Exception {
+	void lastOperationHasSucceededStatus(CapturedOutput output) throws Exception {
 		setupServiceInstanceService(GetLastServiceOperationResponse.builder()
 				.operationState(OperationState.SUCCEEDED)
 				.description("all good")
@@ -835,6 +850,10 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		GetLastServiceOperationRequest actualRequest = verifyLastOperation();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting last operation for service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Getting last operation for service instance succeeded: " +
+				"serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.servicebroker.autoconfigure.web.AbstractServiceInstanceBindingControllerIntegrationTest;
 import org.springframework.cloud.servicebroker.controller.ServiceBrokerWebMvcExceptionHandler;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerCreateOperationInProgressException;
@@ -66,6 +68,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceInstanceBindingControllerIntegrationTest {
 
 	private MockMvc mockMvc;
@@ -78,7 +81,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void createBindingToAppWithoutAsyncAndHeadersSucceeds() throws Exception {
+	void createBindingToAppWithoutAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceBindingService(CreateServiceInstanceAppBindingResponse.builder()
@@ -100,6 +103,11 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 		CreateServiceInstanceBindingRequest actualRequest = verifyCreateBinding();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(false);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Creating service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Creating service instance binding succeeded: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test
@@ -359,7 +367,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void getBindingToAppSucceeds() throws Exception {
+	void getBindingToAppSucceeds(CapturedOutput output) throws Exception {
 		setupServiceInstanceBindingService(GetServiceInstanceAppBindingResponse.builder()
 				.build());
 
@@ -376,6 +384,11 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		GetServiceInstanceBindingRequest actualRequest = verifyGetBinding();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Getting service instance binding succeeded: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test
@@ -434,7 +447,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void deleteBindingWithoutAsyncAndHeadersSucceeds() throws Exception {
+	void deleteBindingWithoutAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceBindingService(DeleteServiceInstanceBindingResponse.builder()
@@ -459,6 +472,11 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 		DeleteServiceInstanceBindingRequest actualRequest = verifyDeleteBinding();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(false);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Deleting service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Deleting service instance binding succeeded: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test
@@ -630,7 +648,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 	}
 
 	@Test
-	void lastOperationHasSucceededStatus() throws Exception {
+	void lastOperationHasSucceededStatus(CapturedOutput output) throws Exception {
 		setupServiceInstanceBindingService(GetLastServiceBindingOperationResponse.builder()
 				.operationState(OperationState.SUCCEEDED)
 				.description("all good")
@@ -650,6 +668,12 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 
 		GetLastServiceBindingOperationRequest actualRequest = verifyLastOperation();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting last operation for service instance binding: serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
+		assertThat(output.getOut()).contains("Getting last operation for service instance binding succeeded: " +
+				"serviceInstanceId="
+				+ SERVICE_INSTANCE_ID + ", bindingId=" + SERVICE_INSTANCE_BINDING_ID);
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.servicebroker.autoconfigure.web.AbstractServiceInstanceControllerIntegrationTest;
 import org.springframework.cloud.servicebroker.controller.ServiceBrokerWebMvcExceptionHandler;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
@@ -71,6 +73,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceControllerIntegrationTest {
 
 	private MockMvc mockMvc;
@@ -84,7 +87,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void createServiceInstanceWithAsyncAndHeadersSucceeds() throws Exception {
+	void createServiceInstanceWithAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceService(CreateServiceInstanceResponse.builder()
@@ -106,6 +109,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 		CreateServiceInstanceRequest actualRequest = verifyCreateServiceInstance();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(true);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Creating service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Creating service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -508,7 +514,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void getServiceInstanceSucceeds() throws Exception {
+	void getServiceInstanceSucceeds(CapturedOutput output) throws Exception {
 		setupServiceInstanceService(GetServiceInstanceResponse.builder()
 				.build());
 
@@ -525,6 +531,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		GetServiceInstanceRequest actualRequest = verifyGetServiceInstance();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Getting service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -566,7 +575,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void deleteServiceInstanceWithAsyncAndHeadersSucceeds() throws Exception {
+	void deleteServiceInstanceWithAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceService(DeleteServiceInstanceResponse.builder()
@@ -588,6 +597,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 		DeleteServiceInstanceRequest actualRequest = verifyDeleteServiceInstance();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(true);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Deleting service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Deleting service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -696,7 +708,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void updateServiceInstanceWithAsyncAndHeadersSucceeds() throws Exception {
+	void updateServiceInstanceWithAsyncAndHeadersSucceeds(CapturedOutput output) throws Exception {
 		setupCatalogService();
 
 		setupServiceInstanceService(UpdateServiceInstanceResponse.builder()
@@ -722,6 +734,9 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 		UpdateServiceInstanceRequest actualRequest = verifyUpdateServiceInstance();
 		assertThat(actualRequest.isAsyncAccepted()).isEqualTo(true);
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Updating service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Updating service instance succeeded: serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test
@@ -890,7 +905,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 	}
 
 	@Test
-	void lastOperationHasSucceededStatus() throws Exception {
+	void lastOperationHasSucceededStatus(CapturedOutput output) throws Exception {
 		setupServiceInstanceService(GetLastServiceOperationResponse.builder()
 				.operationState(OperationState.SUCCEEDED)
 				.description("all good")
@@ -909,6 +924,10 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 
 		GetLastServiceOperationRequest actualRequest = verifyLastOperation();
 		assertHeaderValuesSet(actualRequest);
+
+		assertThat(output.getOut()).contains("Getting last operation for service instance: serviceInstanceId=" + SERVICE_INSTANCE_ID);
+		assertThat(output.getOut()).contains("Getting last operation for service instance succeeded: " +
+				"serviceInstanceId=" + SERVICE_INSTANCE_ID);
 	}
 
 	@Test

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
@@ -60,10 +60,18 @@ public class CatalogController extends BaseController {
 	public Mono<ResponseEntity<Catalog>> getCatalog(@RequestHeader HttpHeaders httpHeaders) {
 		return catalogService.getResponseEntityCatalog(httpHeaders)
 				.switchIfEmpty(catalogService.getCatalog()
-						.doOnRequest(v -> LOG.info("Retrieving catalog"))
+						.doOnRequest(v -> {
+							if (LOG.isInfoEnabled()) {
+								LOG.info("Retrieving catalog");
+							}
+						})
 						.doOnSuccess(catalog -> {
-							LOG.info("Success retrieving catalog");
-							LOG.debug("catalog={}", catalog);
+							if (LOG.isInfoEnabled()) {
+								LOG.info("Retrieving catalog success");
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug("catalog={}", catalog);
+							}
 						})
 						.doOnError(e -> LOG.error("Error retrieving catalog. error=" + e.getMessage(), e))
 						.flatMap(catalog -> Mono.just(ResponseEntity

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -338,7 +338,9 @@ public abstract class ServiceBrokerExceptionHandler {
 	 * @return the error message
 	 */
 	protected ErrorMessage getErrorResponse(ServiceBrokerException ex) {
-		getLog().debug(ex.getMessage(), ex);
+		if (getLog().isDebugEnabled()) {
+			getLog().debug(ex.getMessage(), ex);
+		}
 		return ex.getErrorMessage();
 	}
 
@@ -349,7 +351,9 @@ public abstract class ServiceBrokerExceptionHandler {
 	 * @return the message
 	 */
 	protected OperationInProgressMessage getOperationInProgressMessage(ServiceBrokerOperationInProgressException ex) {
-		getLog().debug(ex.getMessage(), ex);
+		if (getLog().isDebugEnabled()) {
+			getLog().debug(ex.getMessage(), ex);
+		}
 		return ex.getOperationInProgressMessage();
 	}
 

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -60,6 +60,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#binding">Open Service Broker
  * 		API specification</a>
  */
+@SuppressWarnings("PMD.CognitiveComplexity")
 @ServiceBrokerRestController
 public class ServiceInstanceBindingController extends BaseController {
 
@@ -69,7 +70,13 @@ public class ServiceInstanceBindingController extends BaseController {
 
 	private static final String PATH_MAPPING = "/v2/service_instances/{instanceId}/service_bindings/{bindingId}";
 
+	private static final String INFO_REQUEST = "{} service instance binding: serviceInstanceId={}, bindingId={}";
+
+	private static final String INFO_RESPONSE = "{} service instance binding succeeded: serviceInstanceId={}, " +
+			"bindingId={}";
 	private static final String DEBUG_REQUEST = "request={}";
+
+	private static final String DEBUG_RESPONSE = "response={}";
 
 	private final ServiceInstanceBindingService service;
 
@@ -127,13 +134,20 @@ public class ServiceInstanceBindingController extends BaseController {
 				.cast(CreateServiceInstanceBindingRequest.class)
 				.flatMap(req -> service.createServiceInstanceBinding(req)
 						.doOnRequest(v -> {
-							LOG.info("Creating a service instance binding");
-							LOG.debug(DEBUG_REQUEST, req);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Creating", req.getServiceInstanceId(), req.getBindingId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, req);
+							}
 						})
 						.doOnSuccess(response -> {
-							LOG.info("Creating a service instance binding succeeded");
-							LOG.debug("serviceInstanceId={}, bindingId={}, response={}", serviceInstanceId, bindingId,
-									response);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Creating", serviceInstanceId, bindingId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error creating service instance binding. error=" +
 								e.getMessage(), e)))
@@ -189,12 +203,20 @@ public class ServiceInstanceBindingController extends BaseController {
 				.build())
 				.flatMap(req -> service.getServiceInstanceBinding(req)
 						.doOnRequest(v -> {
-							LOG.info("Getting a service instance binding");
-							LOG.debug(DEBUG_REQUEST, req);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Getting", req.getServiceInstanceId(), req.getBindingId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, req);
+							}
 						})
 						.doOnSuccess(response -> {
-							LOG.info("Getting a service instance binding succeeded");
-							LOG.debug("bindingId={}", bindingId);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Getting", serviceInstanceId, bindingId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error getting service instance binding. error=" +
 								e.getMessage(), e)))
@@ -249,12 +271,21 @@ public class ServiceInstanceBindingController extends BaseController {
 				.build())
 				.flatMap(request -> service.getLastOperation(request)
 						.doOnRequest(v -> {
-							LOG.info("Getting service instance binding last operation");
-							LOG.debug(DEBUG_REQUEST, request);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Getting last operation for", request.getServiceInstanceId(),
+										request.getBindingId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, request);
+							}
 						})
-						.doOnSuccess(aVoid -> {
-							LOG.info("Getting service instance binding last operation succeeded");
-							LOG.debug("serviceInstanceId={}, bindingId={}", serviceInstanceId, bindingId);
+						.doOnSuccess(response -> {
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Getting last operation for", serviceInstanceId, bindingId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error getting service instance binding last operation. error=" +
 								e.getMessage(), e)))
@@ -310,12 +341,20 @@ public class ServiceInstanceBindingController extends BaseController {
 								.build()))
 				.flatMap(req -> service.deleteServiceInstanceBinding(req)
 						.doOnRequest(v -> {
-							LOG.info("Deleting a service instance binding");
-							LOG.debug(DEBUG_REQUEST, req);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Deleting", req.getServiceInstanceId(), req.getBindingId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, req);
+							}
 						})
-						.doOnSuccess(aVoid -> {
-							LOG.info("Deleting a service instance binding succeeded");
-							LOG.debug("bindingId={}", bindingId);
+						.doOnSuccess(response -> {
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Deleting", serviceInstanceId, bindingId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error deleting a service instance binding. error=" +
 								e.getMessage(), e)))

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
@@ -61,6 +61,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#provisioning">Open Service
  * 		Broker API specification</a>
  */
+@SuppressWarnings("PMD.CognitiveComplexity")
 @ServiceBrokerRestController
 public class ServiceInstanceController extends BaseController {
 
@@ -70,9 +71,13 @@ public class ServiceInstanceController extends BaseController {
 
 	private static final String PATH_MAPPING = "/v2/service_instances/{instanceId}";
 
+	private static final String INFO_REQUEST = "{} service instance: serviceInstanceId={}";
+
+	private static final String INFO_RESPONSE = "{} service instance succeeded: serviceInstanceId={}";
+
 	private static final String DEBUG_REQUEST = "request={}";
 
-	private static final String DEBUG_RESPONSE = "serviceInstanceId={}, response={}";
+	private static final String DEBUG_RESPONSE = "response={}";
 
 	private final ServiceInstanceService service;
 
@@ -125,12 +130,20 @@ public class ServiceInstanceController extends BaseController {
 				.cast(CreateServiceInstanceRequest.class)
 				.flatMap(req -> service.createServiceInstance(req)
 						.doOnRequest(v -> {
-							LOG.info("Creating a service instance");
-							LOG.debug(DEBUG_REQUEST, req);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Creating", req.getServiceInstanceId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, req);
+							}
 						})
 						.doOnSuccess(response -> {
-							LOG.info("Creating a service instance succeeded");
-							LOG.debug(DEBUG_RESPONSE, serviceInstanceId, response);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Creating", serviceInstanceId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error creating service instance. error=" + e.getMessage(), e)))
 				.map(response -> new ResponseEntity<>(response, getCreateResponseCode(response)))
@@ -182,12 +195,20 @@ public class ServiceInstanceController extends BaseController {
 				.build())
 				.flatMap(request -> service.getServiceInstance(request)
 						.doOnRequest(v -> {
-							LOG.info("Getting service instance");
-							LOG.debug(DEBUG_REQUEST, request);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Getting", request.getServiceInstanceId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, request);
+							}
 						})
 						.doOnSuccess(response -> {
-							LOG.info("Getting service instance succeeded");
-							LOG.debug(DEBUG_RESPONSE, serviceInstanceId, response);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Getting", serviceInstanceId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error getting service instance. error=" + e.getMessage(), e)))
 				.map(response -> new ResponseEntity<>(response, HttpStatus.OK))
@@ -237,12 +258,20 @@ public class ServiceInstanceController extends BaseController {
 				.build())
 				.flatMap(request -> service.getLastOperation(request)
 						.doOnRequest(v -> {
-							LOG.info("Getting service instance last operation");
-							LOG.debug(DEBUG_REQUEST, request);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Getting last operation for", request.getServiceInstanceId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, request);
+							}
 						})
 						.doOnSuccess(response -> {
-							LOG.info("Getting service instance last operation succeeded");
-							LOG.debug(DEBUG_RESPONSE, serviceInstanceId, response);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Getting last operation for", serviceInstanceId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error getting service instance last operation. error=" +
 								e.getMessage(), e)))
@@ -304,12 +333,20 @@ public class ServiceInstanceController extends BaseController {
 								.build()))
 				.flatMap(request -> service.deleteServiceInstance(request)
 						.doOnRequest(v -> {
-							LOG.info("Deleting a service instance");
-							LOG.debug(DEBUG_REQUEST, request);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Deleting", request.getServiceInstanceId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, request);
+							}
 						})
 						.doOnSuccess(response -> {
-							LOG.info("Deleting a service instance succeeded");
-							LOG.debug(DEBUG_RESPONSE, serviceInstanceId, response);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Deleting", serviceInstanceId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error deleting a service instance. error=" + e.getMessage(), e)))
 				.map(response -> new ResponseEntity<>(response, getAsyncResponseCode(response)))
@@ -363,12 +400,20 @@ public class ServiceInstanceController extends BaseController {
 				.cast(UpdateServiceInstanceRequest.class)
 				.flatMap(req -> service.updateServiceInstance(req)
 						.doOnRequest(v -> {
-							LOG.info("Updating service instance");
-							LOG.debug(DEBUG_REQUEST, request);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_REQUEST, "Updating", req.getServiceInstanceId());
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_REQUEST, req);
+							}
 						})
 						.doOnSuccess(response -> {
-							LOG.info("Updating service instance succeeded");
-							LOG.debug(DEBUG_RESPONSE, serviceInstanceId, response);
+							if (LOG.isInfoEnabled()) {
+								LOG.info(INFO_RESPONSE, "Updating", serviceInstanceId);
+							}
+							if (LOG.isDebugEnabled()) {
+								LOG.debug(DEBUG_RESPONSE, response);
+							}
 						})
 						.doOnError(e -> LOG.error("Error updating service instance. error=" + e.getMessage(), e)))
 				.map(response -> new ResponseEntity<>(response, getAsyncResponseCode(response)))


### PR DESCRIPTION
This commit updates the logging calls in ServiceInstanceController and ServiceInstanceBindingController to include the serviceInstanceId and bindingId at the INFO log level.

Closes #434