### PR TITLE
(main) Fix CI image build (#449)

### DIFF
--- a/ci/images/scosb-ci/Dockerfile
+++ b/ci/images/scosb-ci/Dockerfile
@@ -14,5 +14,5 @@ RUN apt-get update && \
         openjdk-17-jdk-headless && \
     apt-get clean
 
-ADD https://raw.githubusercontent.com/spring-io/concourse-java-scripts/v${CONCOURSE_JAVA_SCRIPTS_VERSION}/concourse-java.sh /opt/
-ADD https://repo.spring.io/libs-snapshot/io/spring/concourse/releasescripts/concourse-release-scripts/${CONCOURSE_RELEASE_SCRIPTS_VERSION}/concourse-release-scripts-${CONCOURSE_RELEASE_SCRIPTS_VERSION}.jar /opt/
+ADD "https://raw.githubusercontent.com/spring-io/concourse-java-scripts/v$CONCOURSE_JAVA_SCRIPTS_VERSION/concourse-java.sh" /opt/
+ADD "https://repo.spring.io/ui/native/snapshot/io/spring/concourse/releasescripts/concourse-release-scripts/$CONCOURSE_RELEASE_SCRIPTS_VERSION/concourse-release-scripts-$CONCOURSE_RELEASE_SCRIPTS_VERSION.jar" /opt/

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -18,13 +18,25 @@ aliases:
 jobs:
   - name: build-ci-images
     plan:
+      - get: weekly
+        trigger: true
       - get: ci-images-git-repo
         trigger: true
-      - put: scosb-ci-image
+      - task: build-image
+        privileged: true
+        tags: [ btrfs ]
+        file: ci-images-git-repo/ci/tasks/build-image.yml
+        input_mapping:
+          source: ci-images-git-repo
         params:
-          build: ci-images-git-repo/ci/images/scosb-ci
+          CONTEXT: source/ci/images/scosb-ci
+      - put: scosb-ci-image
+        inputs: detect
+        params:
+          image: image/image.tar
         get_params:
-          skip_download: "true"
+          skip_download: true
+    on_failure: *slack-failure-notification
 
   - name: build
     serial: true
@@ -172,6 +184,17 @@ resource_types:
       tag: latest
 
 resources:
+  - name: weekly
+    type: time
+    icon: calendar-clock
+    source:
+      start: 12:00 AM
+      stop: 1:00 AM
+      days:
+        - Monday
+      location: America/New_York
+      initial_version: true
+
   - name: git-repo
     type: git
     source:
@@ -198,7 +221,7 @@ resources:
       paths: ["ci/images/*"]
 
   - name: scosb-ci-image
-    type: docker-image
+    type: registry-image
     source:
       repository: ((corporate-harbor-registry))/((dockerhub-organization))/scosb-ci
       username: ((corporate-harbor-robot-account.username))

--- a/ci/tasks/build-image.yml
+++ b/ci/tasks/build-image.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: ((dockerhub-mirror-registry))/concourse/oci-build-task
+    tag: 0.11.1
+
+inputs:
+  - name: source
+
+outputs:
+  - name: image
+
+run:
+  path: build
+
+params:
+  CONTEXT:

--- a/scripts/set-pipelines.sh
+++ b/scripts/set-pipelines.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 readonly FLY_TARGET="scosb"
-readonly GITHUB_REPO="https://github.com/spring-cloud/spring-cloud-open-service-broker"
 
 set_pipeline() {
 	local pipeline_name pipeline_definition branch ci_image_tag


### PR DESCRIPTION
* Build was failing with a 401 because repo.spring.io/libs-snapshot is no longer publicly accessible
* We also had an outdated registry password in Vault
* Updated to registry-image resource type and oci-build-task - the old docker-image resource type is now deprecated
* Trigger image build weekly for early warning of failures

fixes #449