### PR TITLE
Fix response code mappings

### DIFF
--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -96,7 +96,7 @@ public abstract class ServiceBrokerExceptionHandler {
 	 * @return an error message
 	 */
 	@ExceptionHandler(ServiceInstanceDoesNotExistException.class)
-	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public ErrorMessage handleException(ServiceInstanceDoesNotExistException ex) {
 		return getErrorResponse(ex);
 	}
@@ -168,7 +168,7 @@ public abstract class ServiceBrokerExceptionHandler {
 	 * @return an error message
 	 */
 	@ExceptionHandler(ServiceBrokerOperationInProgressException.class)
-	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
 	public ErrorMessage handleException(ServiceBrokerOperationInProgressException ex) {
 		return getErrorResponse(ex);
 	}


### PR DESCRIPTION
The exception handler had the response code mappings reversed for ServiceInstanceDoesNotExistException and ServiceBrokerOperationInProgressException.