### PR TITLE
Fix response code mappings 3.6.x

### DIFF
--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceBindingControllerIntegrationTest.java
@@ -268,7 +268,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
 				.expectStatus().is4xxClientError()
-				.expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+				.expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
 				.expectBody()
 				.jsonPath("$.description").isNotEmpty()
 				.consumeWith(result -> assertDescriptionContains(result, String.format("id=%s", SERVICE_INSTANCE_ID)));
@@ -398,7 +398,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 		client.get().uri(buildCreateUrl())
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
-				.expectStatus().isNotFound();
+				.expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
 	}
 
 	@Test
@@ -505,7 +505,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 		client.delete().uri(buildDeleteUrl())
 				.exchange()
 				.expectStatus().is4xxClientError()
-				.expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
+				.expectStatus().isEqualTo(HttpStatus.NOT_FOUND)
 				.expectBody()
 				.jsonPath("$.description").isNotEmpty()
 				.consumeWith(result -> assertDescriptionContains(result, SERVICE_INSTANCE_ID));

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/reactive/ServiceInstanceControllerIntegrationTest.java
@@ -504,7 +504,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.header(ORIGINATING_IDENTITY_HEADER, buildOriginatingIdentityHeader())
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
-				.expectStatus().isNotFound()
+				.expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)
 				.expectBody()
 				.consumeWith(result -> assertDescriptionContains(result, "operation=task_10"));
 	}

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceBindingControllerIntegrationTest.java
@@ -291,7 +291,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.andReturn();
 
 		mockMvc.perform(asyncDispatch(mvcResult))
-				.andExpect(status().isUnprocessableEntity())
+				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.description", containsString(SERVICE_INSTANCE_ID)));
 	}
 
@@ -430,7 +430,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.andReturn();
 
 		mockMvc.perform(asyncDispatch(mvcResult))
-				.andExpect(status().isNotFound());
+				.andExpect(status().isUnprocessableEntity());
 	}
 
 	@Test
@@ -563,7 +563,7 @@ class ServiceInstanceBindingControllerIntegrationTest extends AbstractServiceIns
 				.andReturn();
 
 		mockMvc.perform(asyncDispatch(mvcResult))
-				.andExpect(status().isUnprocessableEntity())
+				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.description", containsString(SERVICE_INSTANCE_ID)));
 	}
 

--- a/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
+++ b/spring-cloud-open-service-broker-autoconfigure/src/test/java/org/springframework/cloud/servicebroker/autoconfigure/web/servlet/ServiceInstanceControllerIntegrationTest.java
@@ -561,7 +561,7 @@ class ServiceInstanceControllerIntegrationTest extends AbstractServiceInstanceCo
 				.andReturn();
 
 		mockMvc.perform(asyncDispatch(mvcResult))
-				.andExpect(status().isNotFound())
+				.andExpect(status().isUnprocessableEntity())
 				.andExpect(jsonPath("$.description", containsString("task_10")));
 	}
 

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/reactive/createAppBindingUnknownId.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/reactive/createAppBindingUnknownId.groovy
@@ -26,7 +26,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         }
     }
     response {
-        status UNPROCESSABLE_ENTITY()
+        status NOT_FOUND()
         body([
                 "description": $(regex('.+id=service-instance-four-id'))
         ])

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/reactive/deleteAppBindingUnknownId.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/reactive/deleteAppBindingUnknownId.groovy
@@ -22,7 +22,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         url '/v2/service_instances/service-instance-four-id/service_bindings/service-binding-one-id?service_id=service-one-id&plan_id=plan-one-id&accepts_incomplete=true'
     }
     response {
-        status UNPROCESSABLE_ENTITY()
+        status NOT_FOUND()
         body([
                 "description": $(regex('.*id=service-instance-four-id'))
         ])

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/reactive/getAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/reactive/getAppBindingInProgress.groovy
@@ -22,7 +22,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         url '/v2/service_instances/service-instance-two-id/service_bindings/service-binding-one-id'
     }
     response {
-        status NOT_FOUND()
+        status UNPROCESSABLE_ENTITY()
         body([
                 "description": $(regex('.*=task_10'))
         ])

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/servlet/createAppBindingUnknownId.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/servlet/createAppBindingUnknownId.groovy
@@ -26,7 +26,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         }
     }
     response {
-        status UNPROCESSABLE_ENTITY()
+        status NOT_FOUND()
         body([
                 "description": $(regex('.+id=service-instance-four-id'))
         ])

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/servlet/deleteAppBindingUnknownId.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/servlet/deleteAppBindingUnknownId.groovy
@@ -22,7 +22,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         url '/v2/service_instances/service-instance-four-id/service_bindings/service-binding-one-id?service_id=service-one-id&plan_id=plan-one-id&accepts_incomplete=true'
     }
     response {
-        status UNPROCESSABLE_ENTITY()
+        status NOT_FOUND()
         body([
                 "description": $(regex('.*id=service-instance-four-id'))
         ])

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/servlet/getAppBindingInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/binding/servlet/getAppBindingInProgress.groovy
@@ -22,7 +22,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         url '/v2/service_instances/service-instance-two-id/service_bindings/service-binding-one-id'
     }
     response {
-        status NOT_FOUND()
+        status UNPROCESSABLE_ENTITY()
         body([
                 "description": $(regex('.*=task_10'))
         ])

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/instance/reactive/getServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/instance/reactive/getServiceInstanceInProgress.groovy
@@ -22,7 +22,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         url '/v2/service_instances/service-instance-two-id'
     }
     response {
-        status NOT_FOUND()
+        status UNPROCESSABLE_ENTITY()
         body([
                 "description": $(regex('.*=task_10'))
         ])

--- a/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/instance/servlet/getServiceInstanceInProgress.groovy
+++ b/spring-cloud-open-service-broker-contract-tests/src/contractTest/resources/contracts/instance/servlet/getServiceInstanceInProgress.groovy
@@ -25,7 +25,7 @@ org.springframework.cloud.contract.spec.Contract.make {
         }
     }
     response {
-        status NOT_FOUND()
+        status UNPROCESSABLE_ENTITY()
         body([
                 "description": $(regex('.*=task_10'))
         ])

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceBrokerExceptionHandler.java
@@ -96,7 +96,7 @@ public abstract class ServiceBrokerExceptionHandler {
 	 * @return an error message
 	 */
 	@ExceptionHandler(ServiceInstanceDoesNotExistException.class)
-	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public ErrorMessage handleException(ServiceInstanceDoesNotExistException ex) {
 		return getErrorResponse(ex);
 	}
@@ -168,7 +168,7 @@ public abstract class ServiceBrokerExceptionHandler {
 	 * @return an error message
 	 */
 	@ExceptionHandler(ServiceBrokerOperationInProgressException.class)
-	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
 	public ErrorMessage handleException(ServiceBrokerOperationInProgressException ex) {
 		return getErrorResponse(ex);
 	}


### PR DESCRIPTION
The exception handler had the response code mappings reversed for ServiceInstanceDoesNotExistException and ServiceBrokerOperationInProgressException.