### PR TITLE
Adds ci/tasks/build-image.* to ci image source resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -218,7 +218,9 @@ resources:
     source:
       uri: ((github-repo))
       branch: ((branch))
-      paths: ["ci/images/*"]
+      paths:
+        - ci/images/*
+        - ci/tasks/build-image.*
 
   - name: scosb-ci-image
     type: registry-image


### PR DESCRIPTION
This path being missing meant Concourse would not see commits that change this file but nothing else in `ci/images`. This is why the `build-ci-images` job in the `3.5.x` pipeline was not triggering with the recent addition of `build-images.yml`.