### PR TITLE
Upgrade to Spring Boot 3.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 buildscript {
 	ext {
 		// Spring Dependencies
-		springBootVersion = "3.0.10"
+		springBootVersion = "3.1.3"
 
 		// External Dependencies
 		beanUtilsVersion = "1.9.4"

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerRequest.java
@@ -33,7 +33,6 @@ public abstract class AsyncServiceBrokerRequest extends ServiceBrokerRequest {
 	 */
 	public final static String ASYNC_REQUEST_PARAMETER = "accepts_incomplete";
 
-	@JsonIgnore //accepts_incomplete Osb field passed as query param in most subclasses
 	protected transient boolean asyncAccepted;
 
 	/**
@@ -70,6 +69,7 @@ public abstract class AsyncServiceBrokerRequest extends ServiceBrokerRequest {
 	 *
 	 * @return the boolean value
 	 */
+	@JsonIgnore //accepts_incomplete Osb field passed as query param in most subclasses
 	public boolean isAsyncAccepted() {
 		return this.asyncAccepted;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceBrokerResponse.java
@@ -34,10 +34,8 @@ public class AsyncServiceBrokerResponse {
 
 	private static final int MAX_OPERATION_LENGTH = 10_000;
 
-	@JsonIgnore //not sent on the wire as json payload, but as http status instead
 	protected final boolean async;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	protected final String operation;
 
 	/**
@@ -59,6 +57,7 @@ public class AsyncServiceBrokerResponse {
 	 *
 	 * @return the boolean value
 	 */
+	@JsonIgnore //not sent on the wire as json payload, but as http status instead
 	public boolean isAsync() {
 		return this.async;
 	}
@@ -68,6 +67,7 @@ public class AsyncServiceBrokerResponse {
 	 *
 	 * @return the operation description
 	 */
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	public String getOperation() {
 		return this.operation;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/Context.java
@@ -51,7 +51,6 @@ public class Context {
 
 	protected final String platform;
 
-	@JsonAnySetter
 	protected final Map<String, Object> properties = new HashMap<>();
 
 	/**
@@ -91,6 +90,17 @@ public class Context {
 	@JsonIgnore
 	public Map<String, Object> getProperties() {
 		return this.properties;
+	}
+
+	/**
+	 * Set a property in the context.
+	 *
+	 * @param key the key of the property
+	 * @param value the value of the property
+	 */
+	@JsonAnySetter
+	public void setProperties(String key, Object value) {
+		this.properties.put(key, value);
 	}
 
 	/**

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/ServiceBrokerRequest.java
@@ -71,16 +71,12 @@ public class ServiceBrokerRequest {
 	 */
 	public static final String PLATFORM_INSTANCE_ID_VARIABLE = "platformInstanceId";
 
-	@JsonIgnore //relative path to Osb query path, not to include in Json body
 	protected transient String platformInstanceId;
 
-	@JsonIgnore //mapped as X-Api-Info-Location Header
 	protected transient String apiInfoLocation;
 
-	@JsonIgnore //mapped as X-Broker-API-Originating-Identity Header
 	protected transient Context originatingIdentity;
 
-	@JsonIgnore //mapped as X-Broker-API-Request-Identity Header
 	protected transient String requestIdentity;
 
 	/**
@@ -116,6 +112,7 @@ public class ServiceBrokerRequest {
 	 *
 	 * @return the platform instance ID, or {@literal null} if not provided
 	 */
+	@JsonIgnore //relative path to Osb query path, not to include in Json body
 	public String getPlatformInstanceId() {
 		return this.platformInstanceId;
 	}
@@ -140,6 +137,7 @@ public class ServiceBrokerRequest {
 	 *
 	 * @return the API info endpoint location, or {@literal null} if not provided
 	 */
+	@JsonIgnore //mapped as X-Api-Info-Location Header
 	public String getApiInfoLocation() {
 		return this.apiInfoLocation;
 	}
@@ -161,6 +159,7 @@ public class ServiceBrokerRequest {
 	 *
 	 * @return the user identity, or {@literal null} if not provided
 	 */
+	@JsonIgnore //mapped as X-Broker-API-Originating-Identity Header
 	public Context getOriginatingIdentity() {
 		return this.originatingIdentity;
 	}
@@ -182,6 +181,7 @@ public class ServiceBrokerRequest {
 	 *
 	 * @return the request identity, or {@literal null} if not provided
 	 */
+	@JsonIgnore //mapped as X-Broker-API-Request-Identity Header
 	public String getRequestIdentity() {
 		return this.requestIdentity;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/BindingMetadata.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/BindingMetadata.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class BindingMetadata {
 
-	@JsonProperty("expires_at")
 	private final String expiresAt;
 
 	/**
@@ -55,6 +54,7 @@ public class BindingMetadata {
 	 *
 	 * @return the date and time in ISO 8601 format
 	 */
+	@JsonProperty("expires_at")
 	public String getExpiresAt() {
 		return expiresAt;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingRequest.java
@@ -48,14 +48,11 @@ import org.springframework.cloud.servicebroker.model.instance.AsyncParameterized
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServiceInstanceRequest {
 
-	@JsonIgnore //OSB field passed as path param
 	private transient String serviceInstanceId;
 
-	@JsonIgnore //OSB field passed as path param
 	private transient String bindingId;
 
 	@NotEmpty
-	@JsonProperty("service_id")
 	private final String serviceDefinitionId;
 
 	@NotEmpty
@@ -66,10 +63,8 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 
 	private final BindResource bindResource;
 
-	@JsonIgnore //internal field
 	private transient ServiceDefinition serviceDefinition;
 
-	@JsonIgnore //internal field
 	private transient Plan plan;
 
 	/**
@@ -126,6 +121,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 	 *
 	 * @return the service instance ID
 	 */
+	@JsonIgnore //OSB field passed as path param
 	public String getServiceInstanceId() {
 		return this.serviceInstanceId;
 	}
@@ -149,6 +145,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 	 *
 	 * @return the service instance ID
 	 */
+	@JsonIgnore //OSB field passed as path param
 	public String getBindingId() {
 		return this.bindingId;
 	}
@@ -172,6 +169,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 	 *
 	 * @return the service definition ID
 	 */
+	@JsonProperty("service_id")
 	public String getServiceDefinitionId() {
 		return this.serviceDefinitionId;
 	}
@@ -226,6 +224,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 	 *
 	 * @return the service definition
 	 */
+	@JsonIgnore //internal field
 	public ServiceDefinition getServiceDefinition() {
 		return this.serviceDefinition;
 	}
@@ -249,6 +248,7 @@ public class CreateServiceInstanceBindingRequest extends AsyncParameterizedServi
 	 *
 	 * @return the plan
 	 */
+	@JsonIgnore //internal field
 	public Plan getPlan() {
 		return this.plan;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/CreateServiceInstanceBindingResponse.java
@@ -39,10 +39,8 @@ import org.springframework.cloud.servicebroker.model.instance.CreateServiceInsta
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class CreateServiceInstanceBindingResponse extends AsyncServiceBrokerResponse {
 
-	@JsonIgnore
 	protected final boolean bindingExisted;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private final BindingMetadata metadata;
 
 	/**
@@ -67,6 +65,7 @@ public class CreateServiceInstanceBindingResponse extends AsyncServiceBrokerResp
 	 *
 	 * @return the boolean value
 	 */
+	@JsonIgnore
 	public boolean isBindingExisted() {
 		return this.bindingExisted;
 	}
@@ -76,6 +75,7 @@ public class CreateServiceInstanceBindingResponse extends AsyncServiceBrokerResp
 	 *
 	 * @return the metadata
 	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public BindingMetadata getMetadata() {
 		return this.metadata;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/DeleteServiceInstanceBindingRequest.java
@@ -41,22 +41,16 @@ import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
  */
 public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerRequest {
 
-	@JsonIgnore // mapped as path param
 	private transient final String serviceInstanceId;
 
-	@JsonIgnore // mapped as path param
 	private transient final String bindingId;
 
-	@JsonProperty("service_id")
 	private transient final String serviceDefinitionId;
 
-	@JsonProperty("plan_id")
 	private transient final String planId;
 
-	@JsonIgnore /*internal field*/
 	private transient final ServiceDefinition serviceDefinition;
 
-	@JsonIgnore /*internal field*/
 	private transient final Plan plan;
 
 	/**
@@ -87,6 +81,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	}
 
 	@JsonProperty(ASYNC_REQUEST_PARAMETER)
+	@JsonIgnore(false)
 	//in base class field is excluded, as other requests are passing this as query params
 	@Override
 	public boolean isAsyncAccepted() {
@@ -101,6 +96,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 *
 	 * @return the service instance ID
 	 */
+	@JsonIgnore // mapped as path param
 	public String getServiceInstanceId() {
 		return this.serviceInstanceId;
 	}
@@ -113,6 +109,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 *
 	 * @return the service instance ID
 	 */
+	@JsonIgnore // mapped as path param
 	public String getBindingId() {
 		return this.bindingId;
 	}
@@ -126,6 +123,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 *
 	 * @return the service definition ID
 	 */
+	@JsonProperty("service_id")
 	public String getServiceDefinitionId() {
 		return this.serviceDefinitionId;
 	}
@@ -140,6 +138,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 *
 	 * @return the plan ID
 	 */
+	@JsonProperty("plan_id")
 	public String getPlanId() {
 		return this.planId;
 	}
@@ -153,6 +152,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 *
 	 * @return the service definition
 	 */
+	@JsonIgnore /*internal field*/
 	public ServiceDefinition getServiceDefinition() {
 		return this.serviceDefinition;
 	}
@@ -166,6 +166,7 @@ public class DeleteServiceInstanceBindingRequest extends AsyncServiceBrokerReque
 	 *
 	 * @return the plan
 	 */
+	@JsonIgnore /*internal field*/
 	public Plan getPlan() {
 		return this.plan;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetLastServiceBindingOperationResponse.java
@@ -44,7 +44,6 @@ public class GetLastServiceBindingOperationResponse {
 
 	private final String description;
 
-	@JsonIgnore
 	private final boolean deleteOperation;
 
 	/**
@@ -90,6 +89,7 @@ public class GetLastServiceBindingOperationResponse {
 	 *
 	 * @return the boolean value
 	 */
+	@JsonIgnore
 	public boolean isDeleteOperation() {
 		return this.deleteOperation;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/GetServiceInstanceBindingResponse.java
@@ -37,7 +37,6 @@ public class GetServiceInstanceBindingResponse {
 
 	private final Map<String, Object> parameters;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private final BindingMetadata metadata;
 
 	/**
@@ -64,6 +63,7 @@ public class GetServiceInstanceBindingResponse {
 	 *
 	 * @return the metadata
 	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public BindingMetadata getMetadata() {
 		return this.metadata;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/VolumeMount.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/binding/VolumeMount.java
@@ -97,16 +97,10 @@ public class VolumeMount {
 
 	private final String containerDir;
 
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonDeserialize(using = ModeDeserializer.class)
 	private final Mode mode;
 
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonDeserialize(using = DeviceTypeDeserializer.class)
 	private final DeviceType deviceType;
 
-	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "device_type")
-	@JsonSubTypes({@JsonSubTypes.Type(value = SharedVolumeDevice.class, name = "shared")})
 	private final VolumeDevice device;
 
 	/**
@@ -156,6 +150,8 @@ public class VolumeMount {
 	 *
 	 * @return the volume read/write mode
 	 */
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonDeserialize(using = ModeDeserializer.class)
 	public Mode getMode() {
 		return this.mode;
 	}
@@ -165,6 +161,8 @@ public class VolumeMount {
 	 *
 	 * @return the volume device type
 	 */
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonDeserialize(using = DeviceTypeDeserializer.class)
 	public DeviceType getDeviceType() {
 		return this.deviceType;
 	}
@@ -174,6 +172,8 @@ public class VolumeMount {
 	 *
 	 * @return the volume device details
 	 */
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "device_type")
+	@JsonSubTypes({@JsonSubTypes.Type(value = SharedVolumeDevice.class, name = "shared")})
 	public VolumeDevice getDevice() {
 		return this.device;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Catalog.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Catalog.java
@@ -40,7 +40,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Catalog {
 
 	@NotEmpty
-	@JsonProperty("services")
 	private final List<ServiceDefinition> serviceDefinitions;
 
 	/**
@@ -64,6 +63,7 @@ public class Catalog {
 	 *
 	 * @return a set of service offerings
 	 */
+	@JsonProperty("services")
 	public List<ServiceDefinition> getServiceDefinitions() {
 		return this.serviceDefinitions;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Schemas.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/Schemas.java
@@ -32,10 +32,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Schemas {
 
-	@JsonProperty("service_instance")
 	private final ServiceInstanceSchema serviceInstanceSchema;
 
-	@JsonProperty("service_binding")
 	private final ServiceBindingSchema serviceBindingSchema;
 
 	/**
@@ -62,6 +60,7 @@ public class Schemas {
 	 *
 	 * @return the schemas
 	 */
+	@JsonProperty("service_instance")
 	public ServiceInstanceSchema getServiceInstanceSchema() {
 		return this.serviceInstanceSchema;
 	}
@@ -71,6 +70,7 @@ public class Schemas {
 	 *
 	 * @return the schemas
 	 */
+	@JsonProperty("service_binding")
 	public ServiceBindingSchema getServiceBindingSchema() {
 		return this.serviceBindingSchema;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceBindingSchema.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceBindingSchema.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ServiceBindingSchema {
 
-	@JsonProperty("create")
 	private final MethodSchema createMethodSchema;
 
 	/**
@@ -56,6 +55,7 @@ public class ServiceBindingSchema {
 	 *
 	 * @return the schema
 	 */
+	@JsonProperty("create")
 	public MethodSchema getCreateMethodSchema() {
 		return this.createMethodSchema;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceInstanceSchema.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/catalog/ServiceInstanceSchema.java
@@ -31,10 +31,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ServiceInstanceSchema {
 
-	@JsonProperty("create")
 	private final MethodSchema createMethodSchema;
 
-	@JsonProperty("update")
 	private final MethodSchema updateMethodSchema;
 
 	/**
@@ -61,6 +59,7 @@ public class ServiceInstanceSchema {
 	 *
 	 * @return the schema
 	 */
+	@JsonProperty("create")
 	public MethodSchema getCreateMethodSchema() {
 		return this.createMethodSchema;
 	}
@@ -70,6 +69,7 @@ public class ServiceInstanceSchema {
 	 *
 	 * @return the schema
 	 */
+	@JsonProperty("update")
 	public MethodSchema getUpdateMethodSchema() {
 		return this.updateMethodSchema;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/ErrorMessage.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/error/ErrorMessage.java
@@ -38,7 +38,6 @@ public class ErrorMessage {
 
 	private final String error;
 
-	@JsonProperty("description")
 	private final String message;
 
 	private final Boolean instanceUsable;
@@ -100,6 +99,7 @@ public class ErrorMessage {
 	 *
 	 * @return the description.
 	 */
+	@JsonProperty("description")
 	public String getMessage() {
 		return this.message;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/AsyncParameterizedServiceInstanceRequest.java
@@ -36,7 +36,6 @@ import org.springframework.util.CollectionUtils;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class AsyncParameterizedServiceInstanceRequest extends AsyncServiceBrokerRequest {
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	protected final Map<String, Object> parameters = new HashMap<>();
 
 	private final Context context;
@@ -81,6 +80,7 @@ public abstract class AsyncParameterizedServiceInstanceRequest extends AsyncServ
 	 *
 	 * @return the populated {@literal Map}
 	 */
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	public Map<String, Object> getParameters() {
 		return this.parameters;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceRequest.java
@@ -49,11 +49,9 @@ import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInstanceRequest {
 
 	@NotEmpty
-	@JsonProperty("service_id")
 	private final String serviceDefinitionId;
 
 	@NotEmpty
-	@JsonProperty("plan_id")
 	private final String planId;
 
 	/**
@@ -70,13 +68,10 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	@JsonProperty("space_guid")
 	private final String spaceGuid;
 
-	@JsonIgnore //mapped as path param
 	private transient String serviceInstanceId;
 
-	@JsonIgnore /*internal field*/
 	private transient ServiceDefinition serviceDefinition;
 
-	@JsonIgnore /*internal field*/
 	private transient Plan plan;
 
 	private final MaintenanceInfo maintenanceInfo;
@@ -139,6 +134,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the service instance ID
 	 */
+	@JsonIgnore //mapped as path param
 	public String getServiceInstanceId() {
 		return this.serviceInstanceId;
 	}
@@ -162,6 +158,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the service definition ID
 	 */
+	@JsonProperty("service_id")
 	public String getServiceDefinitionId() {
 		return this.serviceDefinitionId;
 	}
@@ -176,6 +173,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the plan ID
 	 */
+	@JsonProperty("plan_id")
 	public String getPlanId() {
 		return this.planId;
 	}
@@ -259,6 +257,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the service definition
 	 */
+	@JsonIgnore /*internal field*/
 	public ServiceDefinition getServiceDefinition() {
 		return this.serviceDefinition;
 	}
@@ -277,11 +276,12 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 * Get the plan of the service to create
 	 *
 	 * <p>
-	 * The plan is retreved from the {@link org.springframework.cloud.servicebroker.model.catalog.Catalog} as a
+	 * The plan is retrieved from the {@link org.springframework.cloud.servicebroker.model.catalog.Catalog} as a
 	 * convenience.
 	 *
 	 * @return the plan
 	 */
+	@JsonIgnore /*internal field*/
 	public Plan getPlan() {
 		return this.plan;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/CreateServiceInstanceResponse.java
@@ -39,13 +39,10 @@ import org.springframework.cloud.servicebroker.model.AsyncServiceBrokerResponse;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private final String dashboardUrl;
 
-	@JsonIgnore //not sent on the wire as json payload, but as http status instead
 	private final boolean instanceExisted;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private final ServiceInstanceMetadata metadata;
 
 	/**
@@ -77,6 +74,7 @@ public class CreateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	 *
 	 * @return the dashboard URL, or {@literal null} if not provided
 	 */
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	public String getDashboardUrl() {
 		return this.dashboardUrl;
 	}
@@ -87,6 +85,7 @@ public class CreateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	 *
 	 * @return the boolean value
 	 */
+	@JsonIgnore //not sent on the wire as json payload, but as http status instead
 	public boolean isInstanceExisted() {
 		return this.instanceExisted;
 	}
@@ -96,6 +95,7 @@ public class CreateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	 *
 	 * @return the service instance metadata
 	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public ServiceInstanceMetadata getMetadata() {
 		return this.metadata;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/DeleteServiceInstanceRequest.java
@@ -41,19 +41,14 @@ import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
  */
 public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 
-	@JsonIgnore //mapped as path param
 	private transient final String serviceInstanceId;
 
-	@JsonProperty("service_id")
 	private transient final String serviceDefinitionId;
 
-	@JsonProperty("plan_id")
 	private transient final String planId;
 
-	@JsonIgnore //internal support
 	private transient final ServiceDefinition serviceDefinition;
 
-	@JsonIgnore /*internal field*/
 	private transient final Plan plan;
 
 	/**
@@ -90,6 +85,7 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	 *
 	 * @return the service instance ID
 	 */
+	@JsonIgnore //mapped as path param
 	public String getServiceInstanceId() {
 		return this.serviceInstanceId;
 	}
@@ -103,6 +99,7 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	 *
 	 * @return the service definition ID
 	 */
+	@JsonProperty("service_id")
 	public String getServiceDefinitionId() {
 		return this.serviceDefinitionId;
 	}
@@ -117,6 +114,7 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	 *
 	 * @return the plan ID
 	 */
+	@JsonProperty("plan_id")
 	public String getPlanId() {
 		return this.planId;
 	}
@@ -130,11 +128,13 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	 *
 	 * @return the service definition
 	 */
+	@JsonIgnore //internal support
 	public ServiceDefinition getServiceDefinition() {
 		return this.serviceDefinition;
 	}
 
 	@JsonProperty(ASYNC_REQUEST_PARAMETER)
+	@JsonIgnore(false)
 	//in base class field is excluded, as other requests are passing this as query params
 	@Override
 	public boolean isAsyncAccepted() {
@@ -150,6 +150,7 @@ public class DeleteServiceInstanceRequest extends AsyncServiceBrokerRequest {
 	 *
 	 * @return the plan
 	 */
+	@JsonIgnore /*internal field*/
 	public Plan getPlan() {
 		return this.plan;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetLastServiceOperationResponse.java
@@ -49,7 +49,6 @@ public class GetLastServiceOperationResponse {
 
 	private final Boolean updateRepeatable;
 
-	@JsonIgnore
 	private final boolean deleteOperation;
 
 	/**
@@ -133,6 +132,7 @@ public class GetLastServiceOperationResponse {
 	 *
 	 * @return the boolean value
 	 */
+	@JsonIgnore
 	public boolean isDeleteOperation() {
 		return this.deleteOperation;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/GetServiceInstanceResponse.java
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class GetServiceInstanceResponse {
 
-	@JsonProperty("service_id")
 	private final String serviceDefinitionId;
 
 	private final String planId;
@@ -78,6 +77,7 @@ public class GetServiceInstanceResponse {
 	 *
 	 * @return the service definition ID
 	 */
+	@JsonProperty("service_id")
 	public String getServiceDefinitionId() {
 		return serviceDefinitionId;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/OperationState.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/OperationState.java
@@ -40,7 +40,6 @@ public enum OperationState {
 	 */
 	FAILED("failed");
 
-	@JsonValue
 	private final String state;
 
 	OperationState(String state) {
@@ -52,6 +51,7 @@ public enum OperationState {
 	 *
 	 * @return the {@literal String} value
 	 */
+	@JsonValue
 	public String getValue() {
 		return state;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceRequest.java
@@ -48,7 +48,6 @@ import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInstanceRequest {
 
 	@NotEmpty
-	@JsonProperty("service_id")
 	private final String serviceDefinitionId;
 
 	private final String planId;
@@ -57,13 +56,10 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 
 	private final MaintenanceInfo maintenanceInfo;
 
-	@JsonIgnore
 	private transient String serviceInstanceId;
 
-	@JsonIgnore
 	private transient ServiceDefinition serviceDefinition;
 
-	@JsonIgnore
 	private transient Plan plan;
 
 	/**
@@ -116,6 +112,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the service instance ID
 	 */
+	@JsonIgnore
 	public String getServiceInstanceId() {
 		return this.serviceInstanceId;
 	}
@@ -139,6 +136,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the service definition ID
 	 */
+	@JsonProperty("service_id")
 	public String getServiceDefinitionId() {
 		return this.serviceDefinitionId;
 	}
@@ -178,6 +176,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the service definition
 	 */
+	@JsonIgnore
 	public ServiceDefinition getServiceDefinition() {
 		return this.serviceDefinition;
 	}
@@ -201,6 +200,7 @@ public class UpdateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	 *
 	 * @return the plan
 	 */
+	@JsonIgnore
 	public Plan getPlan() {
 		return this.plan;
 	}

--- a/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponse.java
+++ b/spring-cloud-open-service-broker-core/src/main/java/org/springframework/cloud/servicebroker/model/instance/UpdateServiceInstanceResponse.java
@@ -38,10 +38,8 @@ import org.springframework.cloud.servicebroker.model.AsyncServiceBrokerResponse;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UpdateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private final String dashboardUrl;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private final ServiceInstanceMetadata metadata;
 
 	/**
@@ -70,6 +68,7 @@ public class UpdateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	 *
 	 * @return the dashboard URL, or {@literal null} if not provided
 	 */
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	public String getDashboardUrl() {
 		return this.dashboardUrl;
 	}
@@ -79,6 +78,7 @@ public class UpdateServiceInstanceResponse extends AsyncServiceBrokerResponse {
 	 *
 	 * @return the service instance metadata
 	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public ServiceInstanceMetadata getMetadata() {
 		return this.metadata;
 	}

--- a/spring-cloud-open-service-broker-docs/src/test/java/com/example/servicebroker/ExampleSecurityConfig.java
+++ b/spring-cloud-open-service-broker-docs/src/test/java/com/example/servicebroker/ExampleSecurityConfig.java
@@ -2,8 +2,10 @@ package com.example.servicebroker;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -13,17 +15,12 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class ExampleSecurityConfig {
 
-	// TODO: Update the Spring Security Example
 	@Bean
-	@SuppressWarnings("removal")
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
-				.csrf().disable()
-				.authorizeHttpRequests()
-				.requestMatchers("/v2/**").hasRole("ADMIN")
-				.and()
-				.httpBasic();
-		return http.build();
+		return http.csrf(AbstractHttpConfigurer::disable)
+				.authorizeHttpRequests(httpRequests -> httpRequests.requestMatchers("/v2/**").hasRole("ADMIN"))
+				.httpBasic(Customizer.withDefaults())
+				.build();
 	}
 
 	@Bean

--- a/spring-cloud-open-service-broker-docs/src/test/java/com/example/servicebroker/ExampleSecurityConfig.java
+++ b/spring-cloud-open-service-broker-docs/src/test/java/com/example/servicebroker/ExampleSecurityConfig.java
@@ -13,7 +13,9 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class ExampleSecurityConfig {
 
+	// TODO: Update the Spring Security Example
 	@Bean
+	@SuppressWarnings("removal")
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf().disable()


### PR DESCRIPTION
transient fields annotated with @JsonIgnore were breaking with Jackson 2.15. Moving these annotations to the accessors resolves this. For consistency, all Jackson annotations on the model objects were moved to the accessors.

The Spring Security example still needs to be updated, it now uses deprecated method calls.