### PR TITLE
Use concourse-release-scripts image instead of JAR

### DIFF
--- a/ci/images/scosb-ci/Dockerfile
+++ b/ci/images/scosb-ci/Dockerfile
@@ -15,4 +15,3 @@ RUN apt-get update && \
     apt-get clean
 
 ADD "https://raw.githubusercontent.com/spring-io/concourse-java-scripts/v$CONCOURSE_JAVA_SCRIPTS_VERSION/concourse-java.sh" /opt/
-ADD "https://repo.spring.io/ui/native/snapshot/io/spring/concourse/releasescripts/concourse-release-scripts/$CONCOURSE_RELEASE_SCRIPTS_VERSION/concourse-release-scripts-$CONCOURSE_RELEASE_SCRIPTS_VERSION.jar" /opt/

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -135,7 +135,6 @@ jobs:
         file: git-repo/ci/tasks/promote.yml
         vars:
           release-type: M
-          ci-image-tag: ((ci-image-tag))
 
   - name: promote-rc
     serial: true
@@ -150,7 +149,6 @@ jobs:
         file: git-repo/ci/tasks/promote.yml
         vars:
           release-type: RC
-          ci-image-tag: ((ci-image-tag))
 
   - name: promote-release
     serial: true
@@ -165,7 +163,6 @@ jobs:
         file: git-repo/ci/tasks/promote.yml
         vars:
           release-type: RELEASE
-          ci-image-tag: ((ci-image-tag))
 
   - name: sync-to-maven-central
     serial: true
@@ -178,8 +175,6 @@ jobs:
               save_build_info: true
       - task: sync-to-maven-central
         file: git-repo/ci/tasks/sync-to-maven-central.yml
-        vars:
-          ci-image-tag: ((ci-image-tag))
 
 resource_types:
   - name: artifactory-resource

--- a/ci/scripts/promote.sh
+++ b/ci/scripts/promote.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-# shellcheck source=scripts/common.sh
-source $(dirname $0)/common.sh
+pushd artifactory-repo > /dev/null
+version=$( get_revision_from_buildinfo )
+popd > /dev/null
 
-version=$( cat artifactory-repo/build-info.json | jq -r '.buildInfo.modules[0].id' | sed 's/.*:.*:\(.*\)/\1/' )
-export BUILD_INFO_LOCATION=$(pwd)/artifactory-repo/build-info.json
+readonly BUILD_INFO_LOCATION="$(pwd)/artifactory-repo/build-info.json"
 
-java -jar /opt/concourse-release-scripts*.jar promote $RELEASE_TYPE $BUILD_INFO_LOCATION
+java -jar /concourse-release-scripts.jar promote "$RELEASE_TYPE" "$BUILD_INFO_LOCATION"
 
 echo "Promotion complete"
-echo $version > version/version
+echo "$version" > version/version

--- a/ci/scripts/sync-to-maven-central.sh
+++ b/ci/scripts/sync-to-maven-central.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 readonly BUILD_INFO_LOCATION="$(pwd)/artifactory-repo/build-info.json"
 readonly CONFIG_DIR="$(pwd)/git-repo/ci/config"
 
-java -jar /opt/concourse-release-scripts*.jar \
-  --spring.config.location="${CONFIG_DIR}/release-scripts.yml" \
+java -jar /concourse-release-scripts.jar \
+  --spring.config.location="$CONFIG_DIR/release-scripts.yml" \
   publishToCentral 'RELEASE' "$BUILD_INFO_LOCATION" "artifactory-repo"
 
 echo "Sync complete"

--- a/ci/tasks/promote.yml
+++ b/ci/tasks/promote.yml
@@ -3,10 +3,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((corporate-harbor-registry))/((dockerhub-organization))/scosb-ci
-    username: ((corporate-harbor-robot-account.username))
-    password: ((corporate-harbor-robot-account.password))
-    tag: ((ci-image-tag))
+    repository: ((dockerhub-mirror-registry))/springio/concourse-release-scripts
+    tag: '0.3.4'
 inputs:
   - name: git-repo
   - name: artifactory-repo

--- a/ci/tasks/sync-to-maven-central.yml
+++ b/ci/tasks/sync-to-maven-central.yml
@@ -3,10 +3,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((corporate-harbor-registry))/((dockerhub-organization))/scosb-ci
-    username: ((corporate-harbor-robot-account.username))
-    password: ((corporate-harbor-robot-account.password))
-    tag: ((ci-image-tag))
+    repository: ((dockerhub-mirror-registry))/springio/concourse-release-scripts
+    tag: '0.3.4'
 inputs:
   - name: git-repo
   - name: artifactory-repo


### PR DESCRIPTION
The release version of concourse-release-scripts.jar is no longer publicly available, so switch to using the image instead.