### PR TITLE
(3.6.x) Use Gradle resolutionStrategy to align asciidoctor plugin versions 

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,11 +15,18 @@
  */
 
 pluginManagement {
+	resolutionStrategy {
+		eachPlugin {
+			if (requested.id.namespace?.startsWith('org.asciidoctor.jvm')) {
+				useVersion("4.0.1")
+			}
+		}
+	}
 	plugins {
 		id "org.springframework.boot" version "2.7.18"
 		id "io.spring.nohttp" version "0.0.11"
-		id 'org.asciidoctor.jvm.pdf' version '4.0.1'
-		id 'org.asciidoctor.jvm.convert' version '4.0.1'
+		id 'org.asciidoctor.jvm.pdf'
+		id 'org.asciidoctor.jvm.convert'
 	}
 	repositories {
 		gradlePluginPortal()


### PR DESCRIPTION
All plugins (convert, pdf, etc) are released together and compatibility between versions is not guaranteed.
So, this PR uses 'resolutionStrategy' to assign the same version to all plugins ensuring they are all aligned.