### PR TITLE
Revert gradle property changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,24 @@
  * limitations under the License.
  */
 
+buildscript {
+	ext {
+		// External Dependencies
+		beanUtilsVersion = "1.11.0"
+
+		// Test Dependencies
+		springCloudContractVersion = "4.3.0"
+		javaHamcrestVersion = "2.0.0.0"
+		equalsVerifierVersion = "4.0"
+		findbugsVersion = "3.0.1u2"
+		wiremockStandaloneVersion = "3.0.1"
+
+		// Static Analysis
+		blockHoundVersion = "1.0.13.RELEASE"
+		junitPlatformLauncherVersion = "1.7.0"
+	}
+}
+
 plugins {
 	id 'checkstyle'
 	id 'io.spring.nohttp'
@@ -78,7 +96,7 @@ configure(allprojects - [project(':spring-cloud-open-service-broker-docs')]) {
 	}
 
 	dependencies {
-		checkstyle("io.spring.javaformat:spring-javaformat-checkstyle:${springJavaFormatVersion}")
+		checkstyle("io.spring.javaformat:spring-javaformat-checkstyle:0.0.46")
 	}
 
 	test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,4 @@
-org.gradle.caching=true
-org.gradle.parallel=true
-
 version=4.5.1-SNAPSHOT
 
-#Gradle plugins
-springBootVersion=3.5.3
-springJavaFormatVersion=0.0.46
-asciidoctorVersion=4.0.3
-nohttpVersion=0.0.11
-
-# external dependencies
-beanUtilsVersion=1.11.0
-
-#test dependencies
-springCloudContractVersion=4.3.0
-javaHamcrestVersion=2.0.0.0
-equalsVerifierVersion=4.0
-findbugsVersion=3.0.1u2
-wiremockStandaloneVersion=3.0.1
-
-# static analysis
-blockHoundVersion=1.0.13.RELEASE
-junitPlatformLauncherVersion=1.7.0
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,13 +15,19 @@
  */
 
 pluginManagement {
+	resolutionStrategy {
+		eachPlugin {
+			if (requested.id.namespace?.startsWith('org.asciidoctor.jvm')) {
+				useVersion("4.0.3")
+			}
+		}
+	}
 	plugins {
-		id "org.springframework.boot" version springBootVersion
-		id 'org.springframework.cloud.contract' version springCloudContractVersion
-		id "io.spring.nohttp" version nohttpVersion
-		id "io.spring.javaformat" version springJavaFormatVersion
-		id 'org.asciidoctor.jvm.pdf' version asciidoctorVersion
-		id 'org.asciidoctor.jvm.convert' version asciidoctorVersion
+		id "org.springframework.boot" version "3.5.3"
+		id "io.spring.nohttp" version "0.0.11"
+		id "io.spring.javaformat" version "0.0.46"
+		id 'org.asciidoctor.jvm.pdf'
+		id 'org.asciidoctor.jvm.convert'
 	}
 	repositories {
 		gradlePluginPortal()

--- a/spring-cloud-open-service-broker-contract-tests/build.gradle
+++ b/spring-cloud-open-service-broker-contract-tests/build.gradle
@@ -21,7 +21,7 @@ import org.springframework.cloud.contract.verifier.config.TestMode
 plugins {
 	id 'org.springframework.boot' apply false
 	id 'groovy'
-	id 'org.springframework.cloud.contract'
+	id 'org.springframework.cloud.contract' version "${springCloudContractVersion}"
 }
 
 description = "Spring Cloud Open Service Broker Contract Tests"


### PR DESCRIPTION
dependabot doesn't bump versions in gradle.properties, so reverting the previous change