### PR TITLE
Use new concourse-release-scripts image

### DIFF
--- a/ci/tasks/promote.yml
+++ b/ci/tasks/promote.yml
@@ -3,10 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((open-service-broker-virtual-docker-registry))/springio/concourse-release-scripts
+    repository: ((spring-scs-virtual-docker-registry))/ci/concourse-release-scripts
     username: ((broadcom-jfrog-artifactory-robot-account.username))
     password: ((broadcom-jfrog-artifactory-robot-account.password))
-    tag: '0.3.4'
+    tag: '0.4.2'
 inputs:
   - name: git-repo
   - name: artifactory-repo

--- a/ci/tasks/sync-to-maven-central.yml
+++ b/ci/tasks/sync-to-maven-central.yml
@@ -3,10 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((open-service-broker-virtual-docker-registry))/springio/concourse-release-scripts
+    repository: ((spring-scs-virtual-docker-registry))/ci/concourse-release-scripts
     username: ((broadcom-jfrog-artifactory-robot-account.username))
     password: ((broadcom-jfrog-artifactory-robot-account.password))
-    tag: '0.3.4'
+    tag: '0.4.2'
 inputs:
   - name: git-repo
   - name: artifactory-repo


### PR DESCRIPTION
The new image resolves issues around promoting to maven central in CI.