### PR TITLE
Use Spring Boot managed version of Hamcrest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
 
 		// Test Dependencies
 		springCloudContractVersion = "5.0.2"
-		javaHamcrestVersion = "2.0.0.0"
 		equalsVerifierVersion = "4.4.2"
 		findbugsVersion = "3.0.1u2"
 		wiremockStandaloneVersion = "3.0.1"

--- a/spring-cloud-open-service-broker-autoconfigure/build.gradle
+++ b/spring-cloud-open-service-broker-autoconfigure/build.gradle
@@ -40,7 +40,6 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'jakarta.servlet:jakarta.servlet-api'
 	testImplementation 'org.mockito:mockito-core'
-	testImplementation "org.hamcrest:java-hamcrest:${javaHamcrestVersion}"
 	testImplementation 'org.assertj:assertj-core'
 	testImplementation 'org.apache.commons:commons-lang3'
 }

--- a/spring-cloud-open-service-broker-core/build.gradle
+++ b/spring-cloud-open-service-broker-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 	testImplementation 'org.assertj:assertj-core'
-	testImplementation 'org.hamcrest:hamcrest-library'
+	testImplementation 'org.hamcrest:hamcrest'
 	testImplementation 'org.mockito:mockito-core'
 	testImplementation 'org.mockito:mockito-junit-jupiter'
 	testImplementation 'com.jayway.jsonpath:json-path'


### PR DESCRIPTION
Remove the manually managed version of Hamcrest in favor of the Spring Boot managed version of Hamcrest.