### PR TITLE
Reduce scope of findbugs dependency

### DIFF
--- a/spring-cloud-open-service-broker-core/build.gradle
+++ b/spring-cloud-open-service-broker-core/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 	testImplementation "nl.jqno.equalsverifier:equalsverifier:${equalsVerifierVersion}"
 	testImplementation 'jakarta.servlet:jakarta.servlet-api'
-	testImplementation "com.google.code.findbugs:annotations:${findbugsVersion}"
+	testCompileOnly "com.google.code.findbugs:annotations:${findbugsVersion}"
 }
 
 configurations {


### PR DESCRIPTION
Changes the scope of findbugs from testImplementation to testCompileOnly. byte-buddy uses @SuppressFBWarnings internally and is a transitive dependency of Mockito. The compiler returns a warning if the findbugs dependency is not present.