### PR TITLE
Remove wiremock gradle contraint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ buildscript {
 		springCloudContractVersion = "5.0.2"
 		equalsVerifierVersion = "4.4.2"
 		findbugsVersion = "3.0.1u2"
-		wiremockStandaloneVersion = "3.0.1"
 
 		// Static Analysis
 		blockHoundVersion = "1.0.16.RELEASE"

--- a/spring-cloud-open-service-broker-contract-tests/build.gradle
+++ b/spring-cloud-open-service-broker-contract-tests/build.gradle
@@ -44,12 +44,6 @@ generateContractTests {
 }
 
 dependencies {
-	constraints {
-		testImplementation("com.github.tomakehurst:wiremock-standalone:${wiremockStandaloneVersion}") {
-			because "avoid Logback classpath conflict"
-		}
-	}
-
 	implementation platform("org.springframework.cloud:spring-cloud-contract-dependencies:${springCloudContractVersion}")
 	implementation platform(SpringBootPlugin.BOM_COORDINATES)
 	testImplementation project(':spring-cloud-starter-open-service-broker')


### PR DESCRIPTION
This contraint was previously added to avoid a logback classpath conflict. Since spring cloud contract was upgraded, it is no longer needed.